### PR TITLE
Update MintIngestor to support Contracts. Simplify testing & dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ This library is included in Floor's platform and executed in a sandboxed environ
 Adding a new platform to Mobile Minting is easy - you just have to write a `MintIngestor`!
 
 ### MintIngestor functionality
-A MintIngestor has one simple job:
+A MintIngestor has a simple job:
 
-> Transform a URL into a valid MintTemplate, iff that URL represents a supported mint by the ingestor
+> Transform a URL or contract address into a valid MintTemplate, iff it represents a supported mint by the ingestor
 
 ![template](https://github.com/floornfts/mobile-minting/assets/1068437/7693bfe2-8754-48ba-ac5d-7b222b1435de)
 
@@ -63,12 +63,20 @@ You will create a new folder in `src/ingestors` for your new Ingestor.
 
 ```ts
 export class MyMintIngestor implements MintIngestor {
-  async supportsUrl(url: string): Promise<boolean> {
+  async supportsUrl(resources: MintIngestorResources, url: string): Promise<boolean> {
     // check if URL is supported by your ingestor
   }
 
-  async createMintTemplateForUrl(url: string, resources: MintIngestorResources): Promise<MintTemplate> {
+  async supportsContract(resources: MintIngestorResources, contract: MintContractOptions): Promise<boolean> {
+    // check if the contract is supported by the ingestor
+  }
+
+  async createMintTemplateForUrl(resources: MintIngestorResources, url: string): Promise<MintTemplate> {
     // create the mint template for your URL
+  }
+
+  async createMintForContract(resources: MintIngestorResources, contract: MintContractOptions): Promise<MintTemplate> {
+    // create the mint template for your contract
   }
 }
 ```
@@ -97,6 +105,8 @@ In this example we make a template, relying on `getMintMetadataFromSomewhere()` 
       priceWei: totalPriceWei,
     });
 ```
+
+_Note: You will typically want to implement either 
 
 You can then build the MintTemplate from the builder.
 
@@ -141,6 +151,28 @@ yarn test
 ```
 
 <br />
+
+### Trying out your Mint Ingestor
+You can try your mint ingestory using `yarn dry-run` -- this will:
+
+* Create an instance of your minter
+* Pass the inputs you provide to it
+* Print out the output MintTemplate
+
+```bash
+yarn dry-run <minterSlug> <inputType> <input>
+```
+
+`<minterSlug>`: The key for the ingestor in `ALL_MINT_INGESTORS`
+`<inputType>`: `url` or `contract`
+`<input>`: A full URL for `url`, or a colon delimited fullly qualified address for `contract
+
+Examples:
+```bash
+yarn dry-run prohibition-daily url https://daily.prohibition.art/mint/8453/0x896037d93a231273070dd5f5c9a72aba9a3fe920
+yarn dry-run prohibition-daily contract 8453:0x896037d93a231273070dd5f5c9a72aba9a3fe920
+yarn dry-run some-erc-1155-ingestor contract 8453:contractAddress:tokenId
+```
 
 # Submitting a Mobile Minting Ingestor
 Once you've written a Mobile Minting Ingestor, it needs to be Pull Requested to this repository to be included in the production Floor Mobile Minting ingestion fleet.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "lint": "eslint src/**/*.ts",
     "format": "eslint src/**/*.ts --fix",
     "test": "NODE_OPTIONS=\"--loader ts-node/esm\" c8 mocha --require ts-node/register",
-    "release": "np"
+    "release": "np",
+    "dry-run": "ts-node src/dry-run/index.ts"
   },
   "dependencies": {
     "alchemy-sdk": "^3.3.1",

--- a/src/dry-run/index.ts
+++ b/src/dry-run/index.ts
@@ -1,0 +1,56 @@
+import { ALL_MINT_INGESTORS } from "../ingestors";
+import { mintIngestorResources } from "../lib/resources";
+import dotenv from 'dotenv';
+dotenv.config();
+
+const args = process.argv.slice(2);
+const [ ingesterName, inputType, input ] = args;
+
+if (!ingesterName || !inputType || !input) {
+  console.error('Missing arguments');
+  process.exit(1);
+}
+
+console.log(`Running dry-run\n
+  ingestory: ${ingesterName}\n
+  inputType: ${inputType}
+  input: ${input}`);
+
+const ingestor = ALL_MINT_INGESTORS[ingesterName];
+
+if (!ingestor) {
+  console.error('Ingestor not registered in ALL_MINT_INGESTORS');
+  process.exit(1);
+}
+
+const resources = mintIngestorResources();
+
+(async () => {
+  try {
+    let result;
+    switch (inputType) {
+      case 'url':
+        result = await ingestor.createMintTemplateForUrl(resources, input);
+        break;
+      case 'contract':
+        const [ chainId, contractAddress, tokenId ] = input.split(':');
+        if (!chainId || !contractAddress) {
+          console.error('Invalid contract input');
+          process.exit(1);
+        }
+        result = await ingestor.createMintForContract(resources, {
+          chainId: parseInt(chainId),
+          contractAddress,
+          tokenId
+        });
+        break;
+      default:
+        console.error('Invalid input type');
+        process.exit(1);
+    }
+    console.log(JSON.stringify(result, null, 2));
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+})();

--- a/src/dry-run/index.ts
+++ b/src/dry-run/index.ts
@@ -4,19 +4,19 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 const args = process.argv.slice(2);
-const [ ingesterName, inputType, input ] = args;
+const [ingestorName, inputType, input] = args;
 
-if (!ingesterName || !inputType || !input) {
+if (!ingestorName || !inputType || !input) {
   console.error('Missing arguments');
   process.exit(1);
 }
 
 console.log(`Running dry-run\n
-  ingestory: ${ingesterName}\n
+  ingestory: ${ingestorName}\n
   inputType: ${inputType}
   input: ${input}`);
 
-const ingestor = ALL_MINT_INGESTORS[ingesterName];
+const ingestor = ALL_MINT_INGESTORS[ingestorName];
 
 if (!ingestor) {
   console.error('Ingestor not registered in ALL_MINT_INGESTORS');

--- a/src/ingestors/prohibition-daily/index.ts
+++ b/src/ingestors/prohibition-daily/index.ts
@@ -1,33 +1,63 @@
-import { MintIngestor, MintIngestorResources } from '../../lib/types/mint-ingestor';
+import { MintContractOptions, MintIngestor, MintIngestorResources } from '../../lib/types/mint-ingestor';
 import { MintIngestionErrorName, MintIngestorError } from '../../lib/types/mint-ingestor-error';
 import { MintInstructionType, MintTemplate } from '../../lib/types/mint-template';
 import { MintTemplateBuilder } from '../../lib/builder/mint-template-builder';
 import { PROHIBITION_DAILY_ABI } from './abi';
 import { getProhibitionContractMetadata, getProhibitionMintPriceInEth } from './onchain-metadata';
+import { prohibitionOnchainDataFromUrl, urlForValidProhibitionPage } from './offchain-metadata';
 
 export class ProhibitionDailyIngestor implements MintIngestor {
-  async supportsUrl(url: string): Promise<boolean> {
-    return new URL(url).hostname === 'daily.prohibition.art';
+
+  configuration = {
+    supportsContractIsExpensive: true,
+  };
+
+  async supportsUrl(resources: MintIngestorResources, url: string): Promise<boolean> {
+    if (new URL(url).hostname !== 'daily.prohibition.art') {
+      return false;
+    }
+    const { chainId, contractAddress } = await prohibitionOnchainDataFromUrl(url, resources.fetcher);
+    return !!chainId && !!contractAddress;
   }
 
-  async createMintTemplateForUrl(url: string, resources: MintIngestorResources): Promise<MintTemplate> {
-    const isCompatible = await this.supportsUrl(url);
+  async supportsContract(resources: MintIngestorResources, contract: MintContractOptions): Promise<boolean> {
+    const { chainId, contractAddress } = contract;
+    if (!chainId || !contractAddress) {
+      return false;
+    }
+
+    const url = await urlForValidProhibitionPage(chainId, contractAddress, resources.fetcher);
+    return !!url;
+  }
+
+  async createMintTemplateForUrl(resources: MintIngestorResources, url: string): Promise<MintTemplate> {
+    const isCompatible = await this.supportsUrl(resources, url);
     if (!isCompatible) {
       throw new MintIngestorError(MintIngestionErrorName.IncompatibleUrl, 'Incompatible URL');
     }
 
-    const mintBuilder = new MintTemplateBuilder()
-      .setOriginalUrl(url)
-      .setMintInstructionType(MintInstructionType.EVM_MINT)
-      .setPartnerName('Prohibition');
-
-    // https://daily.prohibition.art/mint/8453/0x20479b19ca05e0b63875a65acf24d81cd0973331
-    const urlParts = url.split('/');
-    const contractAddress = urlParts.pop();
-    const chainId = parseInt(urlParts.pop() || '');
+    const { chainId, contractAddress } = await prohibitionOnchainDataFromUrl(url, resources.fetcher);
 
     if (!chainId || !contractAddress) {
       throw new MintIngestorError(MintIngestionErrorName.MissingRequiredData, 'Missing required data');
+    }
+
+    return this.createMintForContract(resources, { chainId, contractAddress, url });
+  }
+
+  async createMintForContract(resources: MintIngestorResources, contract: MintContractOptions): Promise<MintTemplate> {
+
+    const { chainId, contractAddress } = contract;
+    if (!chainId || !contractAddress) {
+      throw new MintIngestorError(MintIngestionErrorName.MissingRequiredData, 'Missing required data');
+    }
+
+    const mintBuilder = new MintTemplateBuilder()
+      .setMintInstructionType(MintInstructionType.EVM_MINT)
+      .setPartnerName('Prohibition');
+
+    if (contract.url) {
+      mintBuilder.setMarketingUrl(contract.url);
     }
 
     const { name, description, image, startDate, endDate } = await getProhibitionContractMetadata(

--- a/src/ingestors/prohibition-daily/offchain-metadata.ts
+++ b/src/ingestors/prohibition-daily/offchain-metadata.ts
@@ -1,0 +1,26 @@
+import { Axios } from "axios";
+
+export const urlForValidProhibitionPage = async (chainId: number, contractAddress: string, fetcher: Axios): Promise<string | undefined> => {
+    const url = `https://daily.prohibition.art/mint/${chainId}/${contractAddress}`;
+    try {
+        const response = await fetcher.get(url);
+        if (response.status !== 200) {
+            return undefined;
+        }
+        return url;
+    } catch (error) {
+        return undefined;
+    }
+};
+
+export const prohibitionOnchainDataFromUrl = async (url: string, fetcher: Axios): Promise<{ chainId: number | undefined, contractAddress: string | undefined }> => {
+    // https://daily.prohibition.art/mint/8453/0x20479b19ca05e0b63875a65acf24d81cd0973331
+    const urlParts = url.split('/');
+    const contractAddress = urlParts.pop();
+    const chainId = parseInt(urlParts.pop() || '');
+
+    if (!chainId || Number.isNaN(chainId) || !contractAddress || !contractAddress.startsWith('0x')){
+        return { chainId: undefined, contractAddress: undefined };
+    }
+    return { chainId, contractAddress };
+};

--- a/src/lib/builder/mint-template-builder.ts
+++ b/src/lib/builder/mint-template-builder.ts
@@ -11,7 +11,7 @@ export class MintTemplateBuilder {
         name: null,
         featuredImageUrl: null,
         images: [],
-        originalUrl: null,
+        marketingUrl: null,
         mintInstructionType: null,
         mintInstructions: null,
         liveDate: null,
@@ -34,9 +34,6 @@ export class MintTemplateBuilder {
     }
     if (!this.mintTemplate.featuredImageUrl) {
       throw new Error('MintTemplate featuredImageUrl is required');
-    }
-    if (!this.mintTemplate.originalUrl) {
-      throw new Error('MintTemplate originalUrl is required');
     }
     if (!this.mintTemplate.mintInstructionType) {
       throw new Error('MintTemplate mintInstructionType is required');
@@ -80,8 +77,8 @@ export class MintTemplateBuilder {
     return this;
   }
 
-  setOriginalUrl(originalUrl: string) {
-    this.mintTemplate.originalUrl = originalUrl;
+  setMarketingUrl(marketingUrl: string) {
+    this.mintTemplate.marketingUrl = marketingUrl;
     return this;
   }
 
@@ -157,8 +154,8 @@ export class MintTemplateBuilder {
     return this;
   }
 
-  unsetOriginalUrl() {
-    this.mintTemplate.originalUrl = null;
+  unsetMarketingUrl() {
+    this.mintTemplate.marketingUrl = null;
     return this;
   }
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,2 +1,2 @@
 export * from './builder/mint-template-builder';
-export * from './types/'
+export * from './types/';

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -1,5 +1,5 @@
 import { Alchemy, Network } from "alchemy-sdk";
-import { MintIngestorResources } from "../src/lib/types/mint-ingestor";
+import { MintIngestorResources } from "./types/mint-ingestor";
 import axios from "axios";
 
 export const mintIngestorResources = (): MintIngestorResources => {

--- a/src/lib/types/mint-ingestor.ts
+++ b/src/lib/types/mint-ingestor.ts
@@ -2,14 +2,36 @@ import { Alchemy } from 'alchemy-sdk';
 import { MintTemplate } from './mint-template';
 import { AxiosInstance } from 'axios';
 
+export type MintContractOptions = {
+  chainId: number;
+  contractAddress: string;
+  tokenId?: string | undefined;
+  url?: string | undefined;
+};
+
 interface MintIngestor {
-  supportsUrl(url: string): Promise<boolean>;
-  createMintTemplateForUrl(url: string, resources: MintIngestorResources): Promise<MintTemplate>;
+  supportsUrl(resources: MintIngestorResources, url: string): Promise<boolean>;
+  supportsContract(resources: MintIngestorResources, contract: MintContractOptions): Promise<boolean>;
+  createMintTemplateForUrl(resources: MintIngestorResources, url: string): Promise<MintTemplate>;
+  createMintForContract(resources: MintIngestorResources, contract: MintContractOptions): Promise<MintTemplate>;
+
+  configuration?: MintIngestorOptions;
 }
 
 type MintIngestorResources = {
   alchemy: Alchemy;
   fetcher: AxiosInstance;
 };
+
+export type MintIngestorOptions = {
+  /* Expensive Calls
+    * Flag to indicate that the URL check is expensive
+    * This could be an HTTP call that is slow or rate limited
+    
+    These may not be run in test suites in all cases
+  */
+  supportsUrlIsExpensive?: boolean;
+  supportsContractIsExpensive?: boolean;
+}
 
 export { MintIngestor, MintIngestorResources };

--- a/src/lib/types/mint-template.ts
+++ b/src/lib/types/mint-template.ts
@@ -4,7 +4,7 @@ export type MintTemplate = {
 
   featuredImageUrl: string | null;
   images: MintImage[];
-  originalUrl: string;
+  marketingUrl: string;
   creator?: MintArtistMetadata | null;
 
   /* Contract details */

--- a/test/ingestors/prohibition-daily.test.ts
+++ b/test/ingestors/prohibition-daily.test.ts
@@ -1,27 +1,34 @@
 import { expect } from 'chai';
 import { ProhibitionDailyIngestor } from '../../src/ingestors/prohibition-daily';
-import { mintIngestorResources } from '../resources';
+import { mintIngestorResources } from '../../src/lib/resources';
 import { EVMMintInstructions } from '../../src/lib/types/mint-template';
 import { MintTemplateBuilder } from '../../src/lib/builder/mint-template-builder';
+import { basicIngestorTests } from '../shared/basic-ingestor-tests';
+
+const resources = mintIngestorResources();
 
 describe('prohibition-daily', function () {
-    it('supportsUrl: Returns false for an unsupported URL', async function () {
-        const ingestor = new ProhibitionDailyIngestor();
-        const url = 'https://example.com';
-        const result = await ingestor.supportsUrl(url)
-        expect(result).to.be.false;
-    });
-    it('supportsUrl: Returns true for a supported URL', async function () {
-        const ingestor = new ProhibitionDailyIngestor();
-        const url = 'https://daily.prohibition.art/mint/8453/0x4680c6a96941a977feaf71e503f3d0409157e02f';
-        const result = await ingestor.supportsUrl(url)
-        expect(result).to.be.true;
+    basicIngestorTests(new ProhibitionDailyIngestor(), resources, {
+        successUrls: [
+            'https://daily.prohibition.art/mint/8453/0x4680c6a96941a977feaf71e503f3d0409157e02f'
+        ],
+        failureUrls: [
+            'https://daily.prohibition.art/',
+            'https://daily.prohibition.art/mint/8453/0x4680c6a96941a977feaf71e503f3d0409157e02f/extra'
+        ],
+        successContracts: [
+            { chainId: 8453, contractAddress: '0x4680c6a96941a977feaf71e503f3d0409157e02f' }
+        ],
+        failureContracts: [
+            { chainId: 8453, contractAddress: '0x965ef172b303b0bcdc38669df1de3c26bad2db8a' },
+            { chainId: 8453, contractAddress: 'derp' }
+        ]
     });
     it('createMintTemplateForUrl: Returns a mint template for a supported URL', async function () {
         const ingestor = new ProhibitionDailyIngestor();
         const url = 'https://daily.prohibition.art/mint/8453/0x4680c6a96941a977feaf71e503f3d0409157e02f';
-        const resources = mintIngestorResources();
-        const template = await ingestor.createMintTemplateForUrl(url, resources);
+        
+        const template = await ingestor.createMintTemplateForUrl(resources, url);
 
         // Verify that the mint template passed validation
         const builder = new MintTemplateBuilder(template);
@@ -38,7 +45,36 @@ describe('prohibition-daily', function () {
 
         expect(template.featuredImageUrl?.length).to.be.greaterThan(0);
 
-        expect(template.originalUrl).to.equal(url);
+        expect(template.marketingUrl).to.equal(url);
+        expect(template.availableForPurchaseStart?.getTime()).to.equal(1718812800000);
+        expect(template.availableForPurchaseEnd?.getTime()).to.equal(1718899140000);
+    });
+    it('createMintTemplateForContract: Returns a mint template for a supported contract', async function () {
+        const ingestor = new ProhibitionDailyIngestor();
+        const contract = {
+            chainId: 8453,
+            contractAddress: '0x4680c6a96941a977feaf71e503f3d0409157e02f',
+            url: 'https://daily.prohibition.art/mint/8453/0x4680c6a96941a977feaf71e503f3d0409157e02f'
+        };
+        
+        const template = await ingestor.createMintForContract(resources, contract);
+
+        // Verify that the mint template passed validation
+        const builder = new MintTemplateBuilder(template);
+        builder.validateMintTemplate();
+        
+        expect(template.name).to.equal('Equilibrium');
+        expect(template.description).to.equal('An animated mixed media piece inspired by the beautiful harmony between humanity and nature.');
+        const mintInstructions = template.mintInstructions as EVMMintInstructions;
+        
+        expect(mintInstructions.contractAddress).to.equal('0x4680c6a96941a977feaf71e503f3d0409157e02f');
+        expect(mintInstructions.contractMethod).to.equal('mint');
+        expect(mintInstructions.contractParams).to.equal('[address, 1]');
+        expect(mintInstructions.priceWei).to.equal('2300000000000000');
+
+        expect(template.featuredImageUrl?.length).to.be.greaterThan(0);
+
+        expect(template.marketingUrl).to.equal(contract.url);
         expect(template.availableForPurchaseStart?.getTime()).to.equal(1718812800000);
         expect(template.availableForPurchaseEnd?.getTime()).to.equal(1718899140000);
     });

--- a/test/shared/basic-ingestor-tests.ts
+++ b/test/shared/basic-ingestor-tests.ts
@@ -1,0 +1,61 @@
+import { expect } from "chai";
+import { MintContractOptions, MintIngestor, MintIngestorResources } from "../../src/lib/types/mint-ingestor";
+import { MintTemplateBuilder } from "../../src/lib/builder/mint-template-builder";
+
+export const basicIngestorTests = (
+    ingestor: MintIngestor, 
+    resources: MintIngestorResources,
+    cases: {
+        successUrls: string[],
+        failureUrls: string[],
+        successContracts: MintContractOptions[],
+        failureContracts: MintContractOptions[]
+    }
+) => {
+    describe(`${ingestor.constructor.name}-auto`, function () {
+        const { successUrls, failureUrls, successContracts, failureContracts } = cases;
+
+        it('supportsUrl: Returns true for a supported URL', async function () {
+            for (const url of successUrls) {
+                const result = await ingestor.supportsUrl(resources, url)
+                expect(result).to.be.true;
+            }
+        });
+        for (const url of failureUrls) {
+            it(`supportsUrl: Returns false for unsupported url (${url})`, async function () {
+                    const result = await ingestor.supportsUrl(resources, url)
+                    expect(result).to.be.false;
+            });
+        }
+        it('supportsContract: Returns true for a supported contract', async function () {
+            for (const contract of successContracts) {
+                const result = await ingestor.supportsContract(resources, contract)
+                expect(result).to.be.true;
+            }
+        });
+        it('supportsContract: Returns false for an unsupported contract', async function () {
+            for (const contract of failureContracts) {
+                const result = await ingestor.supportsContract(resources, contract)
+                expect(result).to.be.false;
+            }
+        });
+        it('createMintTemplateForUrl: Returns a mint template for a supported URL', async function () {
+            for (const url of successUrls) {
+                const template = await ingestor.createMintTemplateForUrl(resources, url);
+
+                // Verify that the mint template passed validation
+                const builder = new MintTemplateBuilder(template);
+                builder.validateMintTemplate();
+            }
+        });
+        it('createMintForContract: Returns a mint template for a supported contract', async function () {
+            for (const contract of successContracts) {
+                const template = await ingestor.createMintForContract(resources, contract);
+
+                // Verify that the mint template passed validation
+                const builder = new MintTemplateBuilder(template);
+                builder.validateMintTemplate();
+            }
+        });
+    });
+}


### PR DESCRIPTION
This is a breaking change, but we're early, so will coordinate with our first collaborators on the changes.

## Abstract
This update adds new ingestor functionality, while improving testing & dry-running capabilities.

### Ingesting Mints from Contract
Two new methods on `MintIngestor` power ingesting a mint directly from contract.

```ts
  supportsContract(resources: MintIngestorResources, contract: MintContractOptions): Promise<boolean>;
  createMintForContract(resources: MintIngestorResources, contract: MintContractOptions): Promise<MintTemplate>;
```

This will be used not just for convenience, but to allow **automatic discovery** as contracts are indexed in Floor.

If `supportsContract` is an expensive method (e.g. hits an API that you don't want load on), make sure to set the new `configuration.supportsContractIsExpensive` property to control load from Floor.

### Base Tests for Ingestors
There's now a set of basic tests available as `basicIngestorTests` that run some basic integrity tests given working, and not-working URL & contract examples.

Contributors now need only write one or two tests that confirm the output data of an ingestion run.

Example of the new Prohibition Daily test suite:

```ts
describe('prohibition-daily', function () {
    basicIngestorTests(new ProhibitionDailyIngestor(), resources, {
        successUrls: [
            'https://daily.prohibition.art/mint/8453/0x4680c6a96941a977feaf71e503f3d0409157e02f'
        ],
        failureUrls: [
            'https://daily.prohibition.art/',
            'https://daily.prohibition.art/mint/8453/0x4680c6a96941a977feaf71e503f3d0409157e02f/extra'
        ],
        successContracts: [
            { chainId: 8453, contractAddress: '0x4680c6a96941a977feaf71e503f3d0409157e02f' }
        ],
        failureContracts: [
            { chainId: 8453, contractAddress: '0x965ef172b303b0bcdc38669df1de3c26bad2db8a' },
            { chainId: 8453, contractAddress: 'derp' }
        ]
    });

   ....
});
```

### Dry Running an ingestor
A common request (and observation from building ourselves in this repo) is to be able to easily dry-run an ingestor against a URL (or now contract.)

This is now possible with `yarn dry-run`

```bash
yarn dry-run <INGESTOR> <INPUTTYPE> <INPUT>
```

```bash
yarn dry-run prohibition-daily url https://daily.prohibition.art/mint/8453/0x896037d93a231273070dd5f5c9a72aba9a3fe920
yarn dry-run prohibition-daily contract 8453:0x896037d93a231273070dd5f5c9a72aba9a3fe920
yarn dry-run some-erc-1155-ingestor contract 8453:contractAddress:tokenId
```

This PR also includes updates to the Prohibition Daily Mint Ingestor (which is a relatively small changeset)