### PR TITLE
Add test run

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,4 +9,6 @@ jobs:
           persist-credentials: false
 
       - name: Run Tests
-        run: yarn install --userconfig=/dev/null && ALCHEMY_API_KEY=${ALCHEMY_API_KEY} yarn test
+        env:
+          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
+        run: yarn install --userconfig=/dev/null && yarn test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,12 +1,11 @@
 name: Run Tests
 
 on: push
-
+env:
+  ALCHEMY_API_KEY: ${{ env.ALCHEMY_API_KEY }}
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      ALCHEMY_API_KEY: ${{ env.ALCHEMY_API_KEY }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+          
+      - name: Remove .npmrc
+        run: rm -f .npmrc
 
       - name: Run Tests
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,16 @@
+name: Run Tests
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      ALCHEMY_API_KEY: ${{ env.ALCHEMY_API_KEY }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Run Tests
+        run: yarn && yarn test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,4 @@
 name: Run Tests
-env:
-  ALCHEMY_API_KEY: ${{ env.ALCHEMY_API_KEY }}
 on: push
 jobs:
   build:
@@ -11,4 +9,4 @@ jobs:
           persist-credentials: false
 
       - name: Run Tests
-        run: yarn && yarn test
+        run: yarn && ALCHEMY_API_KEY=${ALCHEMY_API_KEY} yarn test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,4 +9,4 @@ jobs:
           persist-credentials: false
 
       - name: Run Tests
-        run: yarn && ALCHEMY_API_KEY=${ALCHEMY_API_KEY} yarn test
+        run: yarn install --userconfig=/dev/null && ALCHEMY_API_KEY=${ALCHEMY_API_KEY} yarn test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,8 +1,7 @@
 name: Run Tests
-
-on: push
 env:
   ALCHEMY_API_KEY: ${{ env.ALCHEMY_API_KEY }}
+on: push
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds test runner.

* Uses `ALCHEMY_API_KEY` from secrets
* Note: Removes .npmrc before run to avoid trying to use the private package repo without credentials