### PR TITLE
Add quantity support for Rodeo & regular Zora mints

### DIFF
--- a/src/ingestors/rodeo/index.ts
+++ b/src/ingestors/rodeo/index.ts
@@ -88,9 +88,11 @@ export class RodeoIngestor implements MintIngestor {
       chainId,
       contractAddress: mintAddress,
       contractMethod: 'mintFromFixedPriceSale',
-      contractParams: `[${sale_terms_id}, 1, address, "${user.address}"]`,
+      contractParams: `[${sale_terms_id}, quantity, address, "${user.address}"]`,
       abi: RODEO_ABI,
       priceWei: totalPrice,
+      mintFeePerTokenWei: totalPrice,
+      supportsQuantity: true,
     });
 
     const startDate = public_sale_start_at ? new Date(public_sale_start_at) : new Date();

--- a/src/ingestors/zora-internal/zora-metadata.ts
+++ b/src/ingestors/zora-internal/zora-metadata.ts
@@ -154,6 +154,7 @@ export class ZoraMetadataProvider {
       abi = ZORA_FIXED_PRICE_ABI;
       contractAddress = tokenDetails.collection.address;
       method = 'mint';
+      supportsQuantity = true;
       params = `["${ZORA_FIXED_PRICE_STRATEGY_ADDRESS}", tokenId, quantity, ["${FLOOR_REFERRER_REWARDS_ADDRESS}"], encodedAddress]`;
     }
 

--- a/src/lib/simulation/simulation.ts
+++ b/src/lib/simulation/simulation.ts
@@ -20,6 +20,9 @@ export const simulateEVMTransactionWithAlchemy = async (
   quantity: number,
   blockNumber?: string,
 ): Promise<{ message: string; success: boolean; rawSimulationResult: any }> => {
+  const amount = mintInstructions.supportsQuantity
+    ? (BigInt(quantity) * BigInt(mintInstructions.mintFeePerTokenWei)).toString()
+    : mintInstructions.mintFeePerTokenWei || mintInstructions.priceWei || '0';
   const network = NETWORKS[mintInstructions.chainId];
   if (!network) {
     console.log(`Unsupported chainId: ${mintInstructions.chainId}. Defaulting to success for now.`);
@@ -35,9 +38,7 @@ export const simulateEVMTransactionWithAlchemy = async (
     to: mintInstructions.contractAddress,
     from: SIGNER1_WALLET,
     data: data,
-    value: BigNumber.from(mintInstructions.priceWei || '0')
-      .toHexString()
-      .replace('0x0', '0x'),
+    value: BigNumber.from(amount).toHexString().replace('0x0', '0x'),
   };
 
   const simResult = await alchemy.transact.simulateExecution(tx, blockNumber ? blockNumber : undefined);
@@ -79,12 +80,15 @@ export const simulateEVMTransactionWithTenderly = async (
   blockNumber?: string,
 ): Promise<{ message: string; success: boolean; rawSimulationResult: any }> => {
   const tenderly = new Tenderly();
+  const amount = mintInstructions.supportsQuantity
+    ? (BigInt(quantity) * BigInt(mintInstructions.mintFeePerTokenWei)).toString()
+    : mintInstructions.mintFeePerTokenWei || mintInstructions.priceWei || '0';
 
   const tx = {
     to: mintInstructions.contractAddress,
     from: SIGNER1_WALLET,
     data: dataForMintInstructions(mintInstructions, quantity),
-    value: BigNumber.from(mintInstructions.priceWei || '0')
+    value: BigNumber.from(amount || '0')
       .toHexString()
       .replace('0x0', '0x'),
     chainId: mintInstructions.chainId,

--- a/src/lib/types/mint-template.ts
+++ b/src/lib/types/mint-template.ts
@@ -47,6 +47,7 @@ export type EVMMintInstructionsInput = {
   priceWei: string;
   supportsQuantity?: boolean | undefined;
   defaultQuantity?: number | undefined;
+  mintFeePerTokenWei?: string | undefined;
 };
 
 export type EVMMintInstructions = EVMMintInstructionsInput & {

--- a/test/ingestors/rodeo.test.ts
+++ b/test/ingestors/rodeo.test.ts
@@ -16,7 +16,10 @@ describe('Rodeo', function () {
         'https://rodeo.club/post/0x68227a4390c15AcEf9265d9B8F65d3fb5cD9f85B/1',
         'https://rodeo.club/post/0x6511cB5ec4dbe28a6F2cbc40d2d1030b6CaBC911/10',
       ],
-      failureUrls: ['https://rodeo.club/post/0x68227a4390c15AcEf9265d9B8F65d3fb5cD9f85', 'https://www.transient.xyz/stacks'],
+      failureUrls: [
+        'https://rodeo.club/post/0x68227a4390c15AcEf9265d9B8F65d3fb5cD9f85',
+        'https://www.transient.xyz/stacks',
+      ],
       successContracts: [
         { chainId: 8453, contractAddress: '0x68227a4390c15AcEf9265d9B8F65d3fb5cD9f85B', tokenId: '1' },
         { chainId: 8453, contractAddress: '0x6511cB5ec4dbe28a6F2cbc40d2d1030b6CaBC911', tokenId: '10' },
@@ -44,7 +47,7 @@ describe('Rodeo', function () {
         description: null,
         contractAddress: '0x132363a3bbf47E06CF642dd18E9173E364546C99',
         contractMethod: 'mintFromFixedPriceSale',
-        contractParams: `[5562, 1, address, "0x18FfAD7FEc51119C55368607e43E6a986edaa831"]`,
+        contractParams: `[5562, quantity, address, "0x18FfAD7FEc51119C55368607e43E6a986edaa831"]`,
         priceWei: '100000000000000',
         featuredImageUrlPattern: /https:\/\/f8n-production-collection-ass.+/,
         availableForPurchaseStart: '2024-08-06T05:47:19',
@@ -77,8 +80,12 @@ describe('Rodeo', function () {
         expect(template.featuredImageUrl).to.match(expected.featuredImageUrlPattern);
 
         expect(template.marketingUrl).to.equal(input.url);
-        expect(template.availableForPurchaseStart?.getTime()).to.equal(new Date(expected.availableForPurchaseStart).getTime());
-        expect(template.availableForPurchaseEnd?.getTime()).to.equal(new Date(expected.availableForPurchaseEnd).getTime());
+        expect(template.availableForPurchaseStart?.getTime()).to.equal(
+          new Date(expected.availableForPurchaseStart).getTime(),
+        );
+        expect(template.availableForPurchaseEnd?.getTime()).to.equal(
+          new Date(expected.availableForPurchaseEnd).getTime(),
+        );
       });
     });
   });
@@ -91,7 +98,7 @@ describe('Rodeo', function () {
           chainId: testCase.chainId,
           contractAddress: testCase.expected.outputContractAddress,
           url: testCase.input.url,
-          tokenId: testCase.input.tokenId
+          tokenId: testCase.input.tokenId,
         };
         const template = await ingestor.createMintForContract(resources, contract);
 
@@ -113,8 +120,12 @@ describe('Rodeo', function () {
         expect(template.featuredImageUrl?.length).to.be.greaterThan(0);
 
         expect(template.marketingUrl).to.equal(contract.url);
-        expect(template.availableForPurchaseStart?.getTime()).to.equal(new Date(testCase.expected.availableForPurchaseStart).getTime());
-        expect(template.availableForPurchaseEnd?.getTime()).to.equal(new Date(testCase.expected.availableForPurchaseEnd).getTime());
+        expect(template.availableForPurchaseStart?.getTime()).to.equal(
+          new Date(testCase.expected.availableForPurchaseStart).getTime(),
+        );
+        expect(template.availableForPurchaseEnd?.getTime()).to.equal(
+          new Date(testCase.expected.availableForPurchaseEnd).getTime(),
+        );
       });
     }
   });


### PR DESCRIPTION
* Adds support in simulations for simulating multi-quantity
* Adds support Zora regular mints & Rodeo mints

Note — whether they show up in-app as quantity will depending on pricing & availability of IAPs for the particular item.