### PR TITLE
Fix Highlight Ingestor

### DIFF
--- a/src/ingestors/highlight/index.ts
+++ b/src/ingestors/highlight/index.ts
@@ -101,7 +101,7 @@ export class HighlightIngestor implements MintIngestor {
       throw new MintIngestorError(MintIngestionErrorName.MissingRequiredData, 'Id not available');
     }
 
-    const totalPriceWei = await getHighlightMintPriceInWei(+vectorId, resources.alchemy);
+    const totalPriceWei = await getHighlightMintPriceInWei(+vectorId, resources.alchemy, collection.standard || collection.contractKind);
 
     if (!totalPriceWei) {
       throw new MintIngestorError(MintIngestionErrorName.MissingRequiredData, 'Price not available');

--- a/src/ingestors/highlight/offchain-metadata.ts
+++ b/src/ingestors/highlight/offchain-metadata.ts
@@ -31,6 +31,7 @@ export const getHighlightCollectionById = async (
           status
           baseUri
           onChainBaseUri
+          standard
         }
       }
     `,

--- a/src/ingestors/highlight/onchain-metadata.ts
+++ b/src/ingestors/highlight/onchain-metadata.ts
@@ -9,13 +9,17 @@ const getContract = async (alchemy: Alchemy): Promise<Contract> => {
   return contract;
 };
 
-export const getHighlightMintPriceInWei = async (vectorId: number, alchemy: Alchemy): Promise<string | undefined> => {
+export const getHighlightMintPriceInWei = async (
+  vectorId: number,
+  alchemy: Alchemy,
+  standard: 'ERC721' | 'ERC1155',
+): Promise<string | undefined> => {
   try {
     const contract = await getContract(alchemy);
     const data = await contract.functions.getAbridgedVector(vectorId);
     const { pricePerToken } = data[0];
 
-    const fee = 800000000000000;
+    const fee = standard.toUpperCase() === 'ERC721' ? 800000000000000 : 400000000000000;
     const totalFee = parseInt(pricePerToken.toString()) + fee;
 
     return `${totalFee}`;

--- a/src/ingestors/highlight/types.ts
+++ b/src/ingestors/highlight/types.ts
@@ -24,6 +24,8 @@ export type CollectionByAddress1 = {
   description: string;
   sampleImages: string[];
   creator: string;
+  contractKind: 'erc721' | 'erc1155'
+  standard: "ERC1155" | "ERC721"
 };
 
 export type CollectionByAddress2 = {


### PR DESCRIPTION
### **User description**
## Fix Highlight ingestor

Set baseFee based on contract type,
ERC721 based NFTs have a 0.0008 ETH baseFee while ERC1155 based NFTs' baseFee are 0.0004 ETH.
These prices are consistent across mainnet and most L2s (except Polygon, etc.).
More info [here](https://support.highlight.xyz/knowledge-base/for-creators/about-highlight/highlight-fees).


___

### **PR Type**
Enhancement


___

### **Description**
- Implemented dynamic base fee calculation for Highlight NFT minting:
  - ERC721 NFTs: 0.0008 ETH base fee
  - ERC1155 NFTs: 0.0004 ETH base fee
- Added contract standard information to collection metadata queries
- Updated type definitions to support contract standard identification
- Enhanced price calculation logic to consider NFT contract type



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add contract standard parameter to price calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ingestors/highlight/index.ts

<li>Updated <code>getHighlightMintPriceInWei</code> function call to include contract <br>standard parameter


</details>


  </td>
  <td><a href="https://github.com/floornfts/mobile-minting/pull/69/files#diff-351d1f951ad359a8c45dc5b99f96d1088a1e28fae911b11f57438ab7c6cde4c6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>offchain-metadata.ts</strong><dd><code>Add standard field to collection metadata query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ingestors/highlight/offchain-metadata.ts

- Added `standard` field to GraphQL query for collection metadata


</details>


  </td>
  <td><a href="https://github.com/floornfts/mobile-minting/pull/69/files#diff-4599b790ed219e29bb6f5c8ce5668c54f149632a3bc3b612c6d554fae654bdad">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>onchain-metadata.ts</strong><dd><code>Implement dynamic base fee calculation by contract type</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/ingestors/highlight/onchain-metadata.ts

<li>Modified <code>getHighlightMintPriceInWei</code> to accept contract standard <br>parameter<br> <li> Implemented dynamic base fee calculation based on contract type <br>(ERC721/ERC1155)


</details>


  </td>
  <td><a href="https://github.com/floornfts/mobile-minting/pull/69/files#diff-d1781f7ef51d42cf6a9ae49c01bc639cf37175c660c3ff17bc0cbdc8e1e8524b">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Add contract type definitions for collections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ingestors/highlight/types.ts

<li>Added <code>contractKind</code> and <code>standard</code> type definitions to <br><code>CollectionByAddress1</code> interface


</details>


  </td>
  <td><a href="https://github.com/floornfts/mobile-minting/pull/69/files#diff-05077ec3a1fb1532eb386f511256d05506204f84fcb6d3a2e9ffd2342250d1bb">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information