### PR TITLE
Repair Highlight Base ingestor

### DIFF
--- a/src/ingestors/highlight/index.ts
+++ b/src/ingestors/highlight/index.ts
@@ -5,34 +5,56 @@ import { MintTemplateBuilder } from '../../lib/builder/mint-template-builder';
 import {
   getHighlightCollectionByAddress,
   getHighlightCollectionById,
+  getHighlightCollectionIdByOnChainId,
+  getHighlightMintContractAddress,
+  getHighlightMintDataForCollection,
   getHighlightMintVectorId,
   getHighlightVectorPriceInWei,
+  isSupportedHighlightChain,
+  normalizeHighlightOnChainCollectionId,
 } from './offchain-metadata';
 import { MINT_CONTRACT_ABI } from './abi';
+import { CollectionByAddress } from './types';
 
-const CONTRACT_ADDRESS = '0x8087039152c472Fa74F47398628fF002994056EA';
+const HIGHLIGHT_HOSTS = new Set(['highlight.xyz', 'www.highlight.xyz']);
+const DEFAULT_END_TIMESTAMP_SECONDS = 1893456000;
+
+const getHighlightMintIdFromUrl = (url: string): string | undefined => {
+  try {
+    const parsedUrl = new URL(url);
+    if (!HIGHLIGHT_HOSTS.has(parsedUrl.hostname)) {
+      return undefined;
+    }
+
+    const [, mintPath, id] = parsedUrl.pathname.split('/');
+    if (mintPath !== 'mint' || !id) {
+      return undefined;
+    }
+
+    return decodeURIComponent(id);
+  } catch (error) {}
+};
+
+const getTimestampSeconds = (value: string, fieldName: string): number => {
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    throw new MintIngestorError(MintIngestionErrorName.MissingRequiredData, `${fieldName} not available`);
+  }
+  return Math.floor(timestamp / 1000);
+};
 
 export class HighlightIngestor implements MintIngestor {
   async supportsUrl(resources: MintIngestorResources, url: string): Promise<boolean> {
-    const id = url.split('/').pop();
-    if (!id) {
+    const collection = await this.getCollectionFromUrl(resources, url);
+    if (!collection) {
       return false;
     }
 
-    const collection = await getHighlightCollectionById(resources, id);
-
-    if (!collection || collection.chainId !== 8453) {
-      return false;
-    }
-
-    const urlPattern = /^https:\/\/highlight\.xyz\/mint\/[a-f0-9]{24}$/;
-    return (
-      new URL(url).hostname === 'www.highlight.xyz' || new URL(url).hostname === 'highlight.xyz' || urlPattern.test(url)
-    );
+    return !!getHighlightMintDataForCollection(collection);
   }
 
   async supportsContract(resources: MintIngestorResources, contractOptions: MintContractOptions): Promise<boolean> {
-    if (contractOptions.chainId !== 8453) {
+    if (!isSupportedHighlightChain(contractOptions.chainId)) {
       return false;
     }
     const collection = await getHighlightCollectionByAddress(resources, contractOptions);
@@ -46,25 +68,61 @@ export class HighlightIngestor implements MintIngestor {
     resources: MintIngestorResources,
     contractOptions: MintContractOptions,
   ): Promise<MintTemplate> {
-    const mintBuilder = new MintTemplateBuilder()
-      .setMintInstructionType(MintInstructionType.EVM_MINT)
-      .setPartnerName('Highlight');
-
-    if (contractOptions.url) {
-      mintBuilder.setMarketingUrl(contractOptions.url);
-    }
-
     const collection = await getHighlightCollectionByAddress(resources, contractOptions);
 
     if (!collection) {
       throw new MintIngestorError(MintIngestionErrorName.CouldNotResolveMint, 'Collection not found');
     }
 
-    const contractAddress = collection.contract;
+    return this.buildMintTemplate(collection, contractOptions.url);
+  }
+
+  async createMintTemplateForUrl(resources: MintIngestorResources, url: string): Promise<MintTemplate> {
+    const collection = await this.getCollectionFromUrl(resources, url);
+    const mintData = collection ? getHighlightMintDataForCollection(collection) : undefined;
+
+    if (!mintData) {
+      throw new MintIngestorError(MintIngestionErrorName.IncompatibleUrl, 'Incompatible URL');
+    }
+
+    return this.buildMintTemplate(mintData, url);
+  }
+
+  private async getCollectionFromUrl(resources: MintIngestorResources, url: string) {
+    const id = getHighlightMintIdFromUrl(url);
+    if (!id) {
+      return undefined;
+    }
+
+    if (/^[a-f0-9]{24}$/i.test(id)) {
+      return getHighlightCollectionById(resources, id);
+    }
+
+    const onChainId = normalizeHighlightOnChainCollectionId(id);
+    if (!onChainId) {
+      return undefined;
+    }
+
+    const collectionId = await getHighlightCollectionIdByOnChainId(resources, onChainId);
+    if (!collectionId) {
+      return undefined;
+    }
+
+    return getHighlightCollectionById(resources, collectionId);
+  }
+
+  private buildMintTemplate(collection: CollectionByAddress, url: string | undefined): MintTemplate {
+    const mintBuilder = new MintTemplateBuilder()
+      .setMintInstructionType(MintInstructionType.EVM_MINT)
+      .setPartnerName('Highlight');
+
+    if (url) {
+      mintBuilder.setMarketingUrl(url);
+    }
+
     const description = collection?.description;
 
     mintBuilder.setName(collection.name).setDescription(description).setFeaturedImageUrl(collection.image.split('?')[0]);
-    mintBuilder.setMintOutputContract({ chainId: 8453, address: contractAddress });
 
     if (collection.sampleImages.length) {
       collection.sampleImages.forEach((url, index) => {
@@ -87,7 +145,7 @@ export class HighlightIngestor implements MintIngestor {
       imageUrl: collection.creatorAccountSettings?.displayAvatar,
     });
 
-    mintBuilder.setMintOutputContract({ chainId: 8453, address: collection.primaryContract });
+    mintBuilder.setMintOutputContract({ chainId: collection.chainId, address: collection.primaryContract });
 
     const vectorId = getHighlightMintVectorId(collection.mintVector);
 
@@ -101,9 +159,15 @@ export class HighlightIngestor implements MintIngestor {
       throw new MintIngestorError(MintIngestionErrorName.MissingRequiredData, 'Price not available');
     }
 
+    const mintContractAddress = getHighlightMintContractAddress(collection.mintVector);
+
+    if (!mintContractAddress) {
+      throw new MintIngestorError(MintIngestionErrorName.MissingRequiredData, 'Mint contract not available');
+    }
+
     mintBuilder.setMintInstructions({
-      chainId: 8453,
-      contractAddress: CONTRACT_ADDRESS,
+      chainId: collection.chainId,
+      contractAddress: mintContractAddress,
       contractMethod: 'vectorMint721',
       contractParams: `[${vectorId}, quantity, address]`,
       abi: MINT_CONTRACT_ABI,
@@ -112,43 +176,17 @@ export class HighlightIngestor implements MintIngestor {
     });
 
     const { mintVector } = collection;
-    const startTimestamp = Math.floor(new Date(mintVector.start).getTime() / 1000);
-    const endTimestamp = mintVector.end ? Math.floor(new Date(mintVector.end).getTime() / 1000) : 1893456000;
+    const startTimestamp = getTimestampSeconds(mintVector.start, 'Start date');
+    const endTimestamp = mintVector.end
+      ? getTimestampSeconds(mintVector.end, 'End date')
+      : DEFAULT_END_TIMESTAMP_SECONDS;
 
     const liveDate = +new Date() > startTimestamp * 1000 ? new Date() : new Date(startTimestamp * 1000);
     mintBuilder
-      .setAvailableForPurchaseStart(new Date(startTimestamp * 1000 || Date.now()))
-      .setAvailableForPurchaseEnd(new Date(endTimestamp * 1000 || '2030-01-01'))
+      .setAvailableForPurchaseStart(new Date(startTimestamp * 1000))
+      .setAvailableForPurchaseEnd(new Date(endTimestamp * 1000))
       .setLiveDate(liveDate);
 
     return mintBuilder.build();
-  }
-
-  async createMintTemplateForUrl(resources: MintIngestorResources, url: string): Promise<MintTemplate> {
-    const isCompatible = await this.supportsUrl(resources, url);
-    if (!isCompatible) {
-      throw new MintIngestorError(MintIngestionErrorName.IncompatibleUrl, 'Incompatible URL');
-    }
-
-    // Example URL: https://highlight.xyz/mint/665fa33f07b3436991e55632
-    const splits = url.split('/');
-    const id = splits.pop();
-    splits.pop();
-
-    if (!id) {
-      throw new MintIngestorError(MintIngestionErrorName.CouldNotResolveMint, 'Url error');
-    }
-
-    const collection = await getHighlightCollectionById(resources, id);
-
-    if (!collection) {
-      throw new MintIngestorError(MintIngestionErrorName.CouldNotResolveMint, 'No such collection');
-    }
-
-    return this.createMintForContract(resources, {
-      chainId: collection.chainId,
-      contractAddress: collection.address,
-      url,
-    });
   }
 }

--- a/src/ingestors/highlight/index.ts
+++ b/src/ingestors/highlight/index.ts
@@ -2,12 +2,11 @@ import { MintContractOptions, MintIngestor, MintIngestorResources } from '../../
 import { MintIngestionErrorName, MintIngestorError } from '../../lib/types/mint-ingestor-error';
 import { MintInstructionType, MintTemplate } from '../../lib/types/mint-template';
 import { MintTemplateBuilder } from '../../lib/builder/mint-template-builder';
-import { getHighlightMetadata, getHighlightMintPriceInWei } from './onchain-metadata';
 import {
   getHighlightCollectionByAddress,
   getHighlightCollectionById,
-  getHighlightCollectionOwnerDetails,
-  getHighlightVectorId,
+  getHighlightMintVectorId,
+  getHighlightVectorPriceInWei,
 } from './offchain-metadata';
 import { MINT_CONTRACT_ABI } from './abi';
 
@@ -64,10 +63,7 @@ export class HighlightIngestor implements MintIngestor {
     const contractAddress = collection.contract;
     const description = collection?.description;
 
-    mintBuilder
-      .setName(collection.name)
-      .setDescription(description)
-      .setFeaturedImageUrl(collection.image.split('?')[0]);
+    mintBuilder.setName(collection.name).setDescription(description).setFeaturedImageUrl(collection.image.split('?')[0]);
     mintBuilder.setMintOutputContract({ chainId: 8453, address: contractAddress });
 
     if (collection.sampleImages.length) {
@@ -80,28 +76,26 @@ export class HighlightIngestor implements MintIngestor {
       throw new MintIngestorError(MintIngestionErrorName.MissingRequiredData, 'Error finding creator');
     }
 
-    const collectionId = collection.id || collection.highlightCollection?.id;
+    const collectionId = collection.id;
 
     if (!collectionId) {
       throw new MintIngestorError(MintIngestionErrorName.MissingRequiredData, 'Collection id not available');
     }
-    const creator = await getHighlightCollectionOwnerDetails(resources, collectionId);
-
     mintBuilder.setCreator({
-      name: creator?.creatorAccountSettings?.displayName || '',
+      name: collection.creatorAccountSettings?.displayName || '',
       walletAddress: collection.creator,
-      imageUrl: creator?.creatorAccountSettings?.displayAvatar,
+      imageUrl: collection.creatorAccountSettings?.displayAvatar,
     });
 
     mintBuilder.setMintOutputContract({ chainId: 8453, address: collection.primaryContract });
 
-    const vectorId = await getHighlightVectorId(resources, collectionId);
+    const vectorId = getHighlightMintVectorId(collection.mintVector);
 
     if (!vectorId) {
       throw new MintIngestorError(MintIngestionErrorName.MissingRequiredData, 'Id not available');
     }
 
-    const totalPriceWei = await getHighlightMintPriceInWei(+vectorId, resources.alchemy);
+    const totalPriceWei = getHighlightVectorPriceInWei(collection.mintVector);
 
     if (!totalPriceWei) {
       throw new MintIngestorError(MintIngestionErrorName.MissingRequiredData, 'Price not available');
@@ -117,13 +111,9 @@ export class HighlightIngestor implements MintIngestor {
       supportsQuantity: true,
     });
 
-    const metadata = await getHighlightMetadata(+vectorId, resources.alchemy);
-
-    if (!metadata) {
-      throw new MintIngestorError(MintIngestionErrorName.MissingRequiredData, 'Missing timestamps');
-    }
-
-    const { startTimestamp, endTimestamp } = metadata;
+    const { mintVector } = collection;
+    const startTimestamp = Math.floor(new Date(mintVector.start).getTime() / 1000);
+    const endTimestamp = mintVector.end ? Math.floor(new Date(mintVector.end).getTime() / 1000) : 1893456000;
 
     const liveDate = +new Date() > startTimestamp * 1000 ? new Date() : new Date(startTimestamp * 1000);
     mintBuilder
@@ -143,7 +133,7 @@ export class HighlightIngestor implements MintIngestor {
     // Example URL: https://highlight.xyz/mint/665fa33f07b3436991e55632
     const splits = url.split('/');
     const id = splits.pop();
-    const chain = splits.pop();
+    splits.pop();
 
     if (!id) {
       throw new MintIngestorError(MintIngestionErrorName.CouldNotResolveMint, 'Url error');

--- a/src/ingestors/highlight/offchain-metadata.ts
+++ b/src/ingestors/highlight/offchain-metadata.ts
@@ -1,24 +1,26 @@
 import { MintContractOptions, MintIngestorResources } from 'src/lib';
-import { Collection, CollectionByAddress, CollectionByAddress1 } from './types';
+import { Collection, CollectionByAddress, HighlightMintVector } from './types';
 
-export const getHighlightCollectionById = async (
+const HIGHLIGHT_API_URL = 'https://api.highlight.xyz:8080/';
+const NATIVE_ETH_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const headers = {
+  accept: 'application/json',
+  'content-type': 'application/json',
+};
+
+const getHighlightCollectionDetails = async (
   resources: MintIngestorResources,
-  id: string,
+  collectionId: string,
 ): Promise<Collection | undefined> => {
-  const url = 'https://api.highlight.xyz:8080/';
-
-  const headers = {
-    accept: 'application/json',
-    'content-type': 'application/json',
-  };
-
   const data = {
     operationName: 'GetCollectionDetails',
     variables: {
-      collectionId: id,
+      collectionId,
+      withEns: true,
     },
     query: `
-      query GetCollectionDetails($collectionId: String!) {
+      query GetCollectionDetails($collectionId: String!, $withEns: Boolean) {
         getPublicCollectionDetails(collectionId: $collectionId) {
           id
           name
@@ -31,129 +33,123 @@ export const getHighlightCollectionById = async (
           status
           baseUri
           onChainBaseUri
+          creatorAddresses {
+            address
+            name
+          }
+          creatorEns
+          creatorAccountSettings(withEns: $withEns) {
+            verified
+            imported
+            displayAvatar
+            displayName
+            walletAddresses
+          }
+          mintVectors {
+            name
+            start
+            end
+            paused
+            price
+            currency
+            chainId
+            onchainMintVectorId
+            paymentCurrency {
+              address
+              decimals
+              symbol
+              type
+              mintFee
+            }
+          }
         }
       }
     `,
   };
 
   try {
-    const resp = await resources.fetcher.post(url, data, { headers });
-    if (!resp.data.data) {
-      throw new Error('Empty response');
-    }
-    return resp.data.data.getPublicCollectionDetails;
+    const resp = await resources.fetcher.post(HIGHLIGHT_API_URL, data, { headers });
+    return resp.data.data?.getPublicCollectionDetails;
   } catch (error) {}
+};
+
+const vectorIdFromOnchainId = (onchainMintVectorId: string): string | undefined => {
+  const vectorId = onchainMintVectorId.split(':').pop();
+  if (!vectorId || !/^\d+$/.test(vectorId)) {
+    return undefined;
+  }
+  return vectorId;
+};
+
+export const getHighlightPrimaryMintVector = (
+  collection: Collection,
+): HighlightMintVector | undefined => {
+  return collection.mintVectors?.find(
+    (vector) =>
+      vector.chainId === 8453 &&
+      !vector.paused &&
+      vector.currency.toLowerCase() === NATIVE_ETH_ADDRESS &&
+      !!vectorIdFromOnchainId(vector.onchainMintVectorId),
+  );
+};
+
+export const getHighlightMintVectorId = (vector: HighlightMintVector): string | undefined => {
+  return vectorIdFromOnchainId(vector.onchainMintVectorId);
+};
+
+export const highlightEthToWei = (amount: string | undefined): bigint => {
+  if (!amount) {
+    return 0n;
+  }
+  const [wholePart, fractionalPart = ''] = amount.split('.');
+  const whole = BigInt(wholePart || '0') * 10n ** 18n;
+  const fractional = BigInt((fractionalPart + '0'.repeat(18)).slice(0, 18));
+  return whole + fractional;
+};
+
+export const getHighlightVectorPriceInWei = (vector: HighlightMintVector): string => {
+  const mintFee = highlightEthToWei(vector.paymentCurrency?.mintFee);
+  const price = highlightEthToWei(vector.price);
+  return (price + mintFee).toString();
+};
+
+export const getHighlightCollectionById = async (
+  resources: MintIngestorResources,
+  id: string,
+): Promise<Collection | undefined> => {
+  return getHighlightCollectionDetails(resources, id);
 };
 
 export const getHighlightCollectionByAddress = async (
   resources: MintIngestorResources,
-  contractOptioons: MintContractOptions,
+  contractOptions: MintContractOptions,
 ): Promise<CollectionByAddress | undefined> => {
   try {
-    const resp = await resources.fetcher(
-      `https://marketplace.highlight.xyz/reservoir/base/collections/v7?id=${contractOptioons.contractAddress}&normalizeRoyalties=false`,
+    const collection = await getHighlightCollectionDetails(
+      resources,
+      `base:${contractOptions.contractAddress}`,
     );
-    const collection1: CollectionByAddress1 = resp.data.collections.find((c: CollectionByAddress) => {
-      return c.id.toLowerCase() === contractOptioons.contractAddress.toLowerCase() && c.chainId === 8453;
-    });
+    if (!collection || collection.chainId !== 8453) {
+      return undefined;
+    }
+    const mintVector = getHighlightPrimaryMintVector(collection);
+    if (!mintVector) {
+      return undefined;
+    }
+    const creator = collection.creatorAddresses?.[0]?.address.toLowerCase() || '';
 
-    const resp2 = await resources.fetcher(
-      `https://marketplace.highlight.xyz/reservoir/base/tokens/v7?collection=${contractOptioons.contractAddress}&limit=1&normalizeRoyalties=false`,
-    );
-    const collection2 = resp2.data.tokens[0];
     return {
-      ...collection1,
-      ...collection2,
+      id: collection.id,
+      chainId: collection.chainId,
+      name: collection.name,
+      description: collection.description,
+      image: collection.collectionImage,
+      sampleImages: [collection.collectionImage],
+      creator,
+      contract: collection.address,
+      primaryContract: collection.address,
+      mintVector,
+      creatorAccountSettings: collection.creatorAccountSettings,
     };
-  } catch (error) {}
-};
-
-export const getHighlightVectorId = async (resources: MintIngestorResources, id: string): Promise<string | undefined> => {
-  const url = 'https://api.highlight.xyz:8080/';
-
-  const headers = {
-    accept: 'application/json',
-    'content-type': 'application/json',
-  };
-
-  const data = {
-    operationName: 'GetCollectionSaleDetails',
-    variables: {
-      collectionId: `base:${id}`,
-    },
-    query: `
-    query GetCollectionSaleDetails($collectionId: String!) {
-      getPublicCollectionDetails(collectionId: $collectionId) {
-        size
-        mintVectors {
-          name
-          start
-          end
-          paused
-          price
-          currency
-          chainId
-          paymentCurrency {
-            address
-            decimals
-            symbol
-            type
-            mintFee
-          }
-          onchainMintVectorId
-        }
-      }
-    }
-  `,
-  };
-
-  try {
-    const resp = await resources.fetcher.post(url, data, { headers });
-    const vectorString = resp.data.data.getPublicCollectionDetails.mintVectors.find(
-      (c: { chainId: number }) => c.chainId === 8453,
-    ).onchainMintVectorId;
-    const vectorId = vectorString.split(':').pop();
-    return vectorId;
-  } catch (error) {}
-};
-
-export const getHighlightCollectionOwnerDetails = async (resources: MintIngestorResources, id: string) => {
-  const url = 'https://api.highlight.xyz:8080/';
-  const data = {
-    operationName: 'GetCollectionCreatorDetails',
-    variables: {
-      withEns: true,
-      collectionId: `base:${id}`,
-    },
-    query: `query GetCollectionCreatorDetails($collectionId: String!, $withEns: Boolean) {
-    getPublicCollectionDetails(collectionId: $collectionId) {
-      id
-      creatorAddresses {
-        address
-        name
-      }
-      creatorEns
-      creatorAccountSettings(withEns: $withEns) {
-        verified
-        imported
-        displayAvatar
-        displayName
-        walletAddresses
-      }
-    }
-  }`,
-  };
-
-  const headers = {
-    accept: 'application/json',
-    'content-type': 'application/json',
-  };
-
-  try {
-    const resp = await resources.fetcher.post(url, data, { headers });
-    if (resp.data.errors) {
-      throw new Error("Error fetching owner");
-    }
-    return resp.data.data.getPublicCollectionDetails;
   } catch (error) {}
 };

--- a/src/ingestors/highlight/offchain-metadata.ts
+++ b/src/ingestors/highlight/offchain-metadata.ts
@@ -3,6 +3,17 @@ import { Collection, CollectionByAddress, HighlightMintVector } from './types';
 
 const HIGHLIGHT_API_URL = 'https://api.highlight.xyz:8080/';
 const NATIVE_ETH_ADDRESS = '0x0000000000000000000000000000000000000000';
+const EVM_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+const SUPPORTED_HIGHLIGHT_CHAIN_IDS = new Set([1, 8453]);
+const HIGHLIGHT_CHAIN_ID_BY_PREFIX: Record<string, number> = {
+  eth: 1,
+  ethereum: 1,
+  base: 8453,
+};
+const HIGHLIGHT_CHAIN_PREFIX_BY_ID: Record<number, string> = {
+  1: 'ethereum',
+  8453: 'base',
+};
 
 const headers = {
   accept: 'application/json',
@@ -73,7 +84,10 @@ const getHighlightCollectionDetails = async (
   } catch (error) {}
 };
 
-const vectorIdFromOnchainId = (onchainMintVectorId: string): string | undefined => {
+const vectorIdFromOnchainId = (onchainMintVectorId: string | null): string | undefined => {
+  if (!onchainMintVectorId) {
+    return undefined;
+  }
   const vectorId = onchainMintVectorId.split(':').pop();
   if (!vectorId || !/^\d+$/.test(vectorId)) {
     return undefined;
@@ -81,14 +95,67 @@ const vectorIdFromOnchainId = (onchainMintVectorId: string): string | undefined 
   return vectorId;
 };
 
+const mintContractAddressFromOnchainId = (onchainMintVectorId: string | null): string | undefined => {
+  const mintContractAddress = onchainMintVectorId?.split(':')[1];
+  if (!mintContractAddress || !EVM_ADDRESS_REGEX.test(mintContractAddress)) {
+    return undefined;
+  }
+  return mintContractAddress;
+};
+
+export const isSupportedHighlightChain = (chainId: number): boolean => {
+  return SUPPORTED_HIGHLIGHT_CHAIN_IDS.has(chainId);
+};
+
+export const normalizeHighlightOnChainCollectionId = (id: string): string | undefined => {
+  const [chain, contractAddress, editionId = '0'] = id.split(':');
+  if (!chain || !contractAddress || id.split(':').length > 3) {
+    return undefined;
+  }
+
+  const chainId = /^\d+$/.test(chain) ? Number(chain) : HIGHLIGHT_CHAIN_ID_BY_PREFIX[chain.toLowerCase()];
+  if (!chainId || !isSupportedHighlightChain(chainId) || !EVM_ADDRESS_REGEX.test(contractAddress)) {
+    return undefined;
+  }
+
+  return `${chainId}:${contractAddress}:${editionId || '0'}`;
+};
+
+export const getHighlightCollectionIdByOnChainId = async (
+  resources: MintIngestorResources,
+  onChainId: string,
+): Promise<string | undefined> => {
+  const data = {
+    operationName: 'GetCollectionByOnChainId',
+    variables: {
+      onChainId,
+    },
+    query: `
+      query GetCollectionByOnChainId($onChainId: String!) {
+        getCollectionByOnChainId(onChainId: $onChainId) {
+          id
+          name
+        }
+      }
+    `,
+  };
+
+  try {
+    const resp = await resources.fetcher.post(HIGHLIGHT_API_URL, data, { headers });
+    return resp.data.data?.getCollectionByOnChainId?.id;
+  } catch (error) {}
+};
+
 export const getHighlightPrimaryMintVector = (
   collection: Collection,
+  chainId: number = collection.chainId,
 ): HighlightMintVector | undefined => {
   return collection.mintVectors?.find(
     (vector) =>
-      vector.chainId === 8453 &&
+      vector.chainId === chainId &&
       !vector.paused &&
       vector.currency.toLowerCase() === NATIVE_ETH_ADDRESS &&
+      !!mintContractAddressFromOnchainId(vector.onchainMintVectorId) &&
       !!vectorIdFromOnchainId(vector.onchainMintVectorId),
   );
 };
@@ -97,19 +164,32 @@ export const getHighlightMintVectorId = (vector: HighlightMintVector): string | 
   return vectorIdFromOnchainId(vector.onchainMintVectorId);
 };
 
-export const highlightEthToWei = (amount: string | undefined): bigint => {
-  if (!amount) {
-    return 0n;
+export const getHighlightMintContractAddress = (vector: HighlightMintVector): string | undefined => {
+  return mintContractAddressFromOnchainId(vector.onchainMintVectorId);
+};
+
+export const highlightEthToWei = (amount: string | undefined | null): bigint | undefined => {
+  if (amount === undefined || amount === null) {
+    return undefined;
   }
-  const [wholePart, fractionalPart = ''] = amount.split('.');
+
+  const normalizedAmount = amount.trim();
+  if (!/^\d+(\.\d+)?$/.test(normalizedAmount)) {
+    return undefined;
+  }
+
+  const [wholePart, fractionalPart = ''] = normalizedAmount.split('.');
   const whole = BigInt(wholePart || '0') * 10n ** 18n;
   const fractional = BigInt((fractionalPart + '0'.repeat(18)).slice(0, 18));
   return whole + fractional;
 };
 
-export const getHighlightVectorPriceInWei = (vector: HighlightMintVector): string => {
+export const getHighlightVectorPriceInWei = (vector: HighlightMintVector): string | undefined => {
   const mintFee = highlightEthToWei(vector.paymentCurrency?.mintFee);
   const price = highlightEthToWei(vector.price);
+  if (mintFee === undefined || price === undefined) {
+    return undefined;
+  }
   return (price + mintFee).toString();
 };
 
@@ -120,36 +200,78 @@ export const getHighlightCollectionById = async (
   return getHighlightCollectionDetails(resources, id);
 };
 
+const getHighlightCollectionByOnChainId = async (
+  resources: MintIngestorResources,
+  onChainId: string,
+): Promise<Collection | undefined> => {
+  const collectionId = await getHighlightCollectionIdByOnChainId(resources, onChainId);
+  if (!collectionId) {
+    return undefined;
+  }
+  return getHighlightCollectionDetails(resources, collectionId);
+};
+
+const getCreatorAddress = (collection: Collection): string | undefined => {
+  const creatorAddress =
+    collection.creatorAddresses?.find(({ address }) => EVM_ADDRESS_REGEX.test(address))?.address ||
+    collection.creatorAccountSettings?.walletAddresses?.find((address) => EVM_ADDRESS_REGEX.test(address));
+
+  return creatorAddress?.toLowerCase();
+};
+
+export const getHighlightMintDataForCollection = (
+  collection: Collection,
+  chainId: number = collection.chainId,
+): CollectionByAddress | undefined => {
+  if (collection.chainId !== chainId || !isSupportedHighlightChain(collection.chainId) || !collection.collectionImage) {
+    return undefined;
+  }
+
+  const mintVector = getHighlightPrimaryMintVector(collection, chainId);
+  const creator = getCreatorAddress(collection);
+
+  if (!mintVector || !creator) {
+    return undefined;
+  }
+
+  return {
+    id: collection.id,
+    chainId: collection.chainId,
+    name: collection.name,
+    description: collection.description,
+    image: collection.collectionImage,
+    sampleImages: [collection.collectionImage],
+    creator,
+    contract: collection.address,
+    primaryContract: collection.address,
+    mintVector,
+    creatorAccountSettings: collection.creatorAccountSettings,
+  };
+};
+
 export const getHighlightCollectionByAddress = async (
   resources: MintIngestorResources,
   contractOptions: MintContractOptions,
 ): Promise<CollectionByAddress | undefined> => {
-  try {
-    const collection = await getHighlightCollectionDetails(
-      resources,
-      `base:${contractOptions.contractAddress}`,
-    );
-    if (!collection || collection.chainId !== 8453) {
-      return undefined;
-    }
-    const mintVector = getHighlightPrimaryMintVector(collection);
-    if (!mintVector) {
-      return undefined;
-    }
-    const creator = collection.creatorAddresses?.[0]?.address.toLowerCase() || '';
+  if (!isSupportedHighlightChain(contractOptions.chainId)) {
+    return undefined;
+  }
 
-    return {
-      id: collection.id,
-      chainId: collection.chainId,
-      name: collection.name,
-      description: collection.description,
-      image: collection.collectionImage,
-      sampleImages: [collection.collectionImage],
-      creator,
-      contract: collection.address,
-      primaryContract: collection.address,
-      mintVector,
-      creatorAccountSettings: collection.creatorAccountSettings,
-    };
+  try {
+    const collection =
+      (await getHighlightCollectionByOnChainId(
+        resources,
+        `${contractOptions.chainId}:${contractOptions.contractAddress}:0`,
+      )) ||
+      (await getHighlightCollectionDetails(
+        resources,
+        `${HIGHLIGHT_CHAIN_PREFIX_BY_ID[contractOptions.chainId]}:${contractOptions.contractAddress}`,
+      ));
+
+    if (!collection) {
+      return undefined;
+    }
+
+    return getHighlightMintDataForCollection(collection, contractOptions.chainId);
   } catch (error) {}
 };

--- a/src/ingestors/highlight/types.ts
+++ b/src/ingestors/highlight/types.ts
@@ -30,13 +30,13 @@ export type HighlightMintVector = {
   price: string;
   currency: string;
   chainId: number;
-  onchainMintVectorId: string;
+  onchainMintVectorId: string | null;
   paymentCurrency?: {
     address: string;
     decimals: number;
     symbol: string;
     type: string;
-    mintFee: string;
+    mintFee: string | null;
   } | null;
 };
 

--- a/src/ingestors/highlight/types.ts
+++ b/src/ingestors/highlight/types.ts
@@ -10,47 +10,46 @@ export type Collection = {
   chainId: number;
   status: string;
   baseUri: string;
+  creatorAddresses?: {
+    address: string;
+    name: string | null;
+  }[];
+  creatorAccountSettings?: {
+    displayAvatar?: string | null;
+    displayName?: string | null;
+    walletAddresses?: string[];
+  } | null;
+  mintVectors?: HighlightMintVector[];
 };
 
-export type CollectionByAddress1 = {
-  chainId: number;
-  id: string;
-  createdAt: string;
-  updatedAt: string;
-  contractDeployedAt: string;
+export type HighlightMintVector = {
   name: string;
-  image: string;
-  symbol: string;
+  start: string;
+  end: string | null;
+  paused: boolean;
+  price: string;
+  currency: string;
+  chainId: number;
+  onchainMintVectorId: string;
+  paymentCurrency?: {
+    address: string;
+    decimals: number;
+    symbol: string;
+    type: string;
+    mintFee: string;
+  } | null;
+};
+
+export type CollectionByAddress = {
+  id: string;
+  chainId: number;
+  name: string;
   description: string;
+  image: string;
   sampleImages: string[];
   creator: string;
-};
-
-export type CollectionByAddress2 = {
-  chainId: number;
   contract: string;
-  highlightCollection: {
-    // Vector id
-    id: string;
-    name: string;
-    owner: string;
-    imageUrl: string;
-    animationUrl: string;
-    address: string;
-  };
-};
-
-export type CollectionByAddress3 = {
-  collection: {
-    // Collection address
-    id: string;
-    name: string;
-    creator: string;
-    image: string;
-    animationUrl: string;
-    address: string;
-  };
   primaryContract: string;
+  mintVector: HighlightMintVector;
+  creatorAccountSettings?: Collection["creatorAccountSettings"];
 };
-
-export type CollectionByAddress = CollectionByAddress1 & CollectionByAddress2 & CollectionByAddress3;

--- a/test/ingestors/highlight.test.ts
+++ b/test/ingestors/highlight.test.ts
@@ -71,7 +71,7 @@ describe('highlight', function () {
     expect(mintInstructions.priceWei).to.equal('800000000000000');
 
     expect(template.featuredImageUrl).to.equal(
-      'https://img.reservoir.tools/images/v2/base/z9JRSpLYGu7%2BCZoKWtAuAI37ZMpGmBWtUpAQDl1tI6DEJRvIrkDVCqzOxkdek%2BfesLtA3sYS0SXZeU4voi8R9rQD1uumcaPxveg8%2B3UfVgFBR82zeA%2FzrfIHHRUbhHMTK4V08qvpcJ5dRYdYVwRvZPTKTulv78c%2FB6vgLUkdfSX0ND53Mjp2wUysnfKmYO5rOIxPwl1ACpM%2BOQDWOOSOzg%3D%3D',
+      'https://highlight-creator-assets.highlight.xyz/main/image/ecc4d99e-72e5-4bf4-a823-4e8ebca2dce5.png',
     );
 
     if (template.creator) {
@@ -107,7 +107,7 @@ describe('highlight', function () {
     expect(mintInstructions.priceWei).to.equal('800000000000000');
 
     expect(template.featuredImageUrl).to.equal(
-      'https://img.reservoir.tools/images/v2/base/z9JRSpLYGu7%2BCZoKWtAuAKM5v2dthdDNgoFYsopVhfXBHjSfVbMXHiaW1XsdogS5oNzhOcvyJcxoIKiiKqHsNxiXyJX%2B%2BppNtkeQvHYCslZTqG21HhITlOtTV8jhhZhOQdWST4CHb1DA%2B5K8ZAHTSu9b0MV4dWJJsqPVJ439DhVcURxmw1fKJ4pAhC3iCwl1DOXK1xnEOnLO0il04rMAPA%3D%3D',
+      'https://highlight-creator-assets.highlight.xyz/main/image/085fb994-dc1d-4bc3-9c9e-7ab06c024935.gif',
     );
 
     if (template.creator) {

--- a/test/ingestors/highlight.test.ts
+++ b/test/ingestors/highlight.test.ts
@@ -15,6 +15,7 @@ describe('highlight', function () {
       successUrls: [
         'https://highlight.xyz/mint/66856628ff8a01fdccc132f4',
         'https://highlight.xyz/mint/66d03b0eaae45d4534822482',
+        'https://highlight.xyz/mint/ethereum%3A0x17747Ba2c75CF60d274BCD36210A5b4408A18A6E%3A0',
       ],
       failureUrls: [
         'https://highlight.xyz/mint/66963c500b48236f1acf322b',
@@ -23,6 +24,7 @@ describe('highlight', function () {
       successContracts: [
         { chainId: 8453, contractAddress: '0x0E5DDe3De7cf2761d8a81Ee68F48410425e2dBbA' },
         { chainId: 8453, contractAddress: '0x7022a51D648CEB4f4D290a81A0E543979a003e86' },
+        { chainId: 1, contractAddress: '0x17747Ba2c75CF60d274BCD36210A5b4408A18A6E' },
       ],
       failureContracts: [{ chainId: 5000, contractAddress: '0x62F8C536De24ED32611f128f64F6eAbd9b82176c' }],
     },
@@ -120,6 +122,43 @@ describe('highlight', function () {
 
     expect(template.marketingUrl).to.equal(url);
     expect(template.availableForPurchaseStart?.getTime()).to.equal(+new Date('2024-06-20T17:00:04.000Z'));
+    expect(template.availableForPurchaseEnd?.getTime()).to.equal(+new Date('2030-01-01T00:00:00.000Z'));
+  });
+
+  it('createMintTemplateForUrl: Returns a mint template for a supported Ethereum URL', async function () {
+    const ingestor = new HighlightIngestor();
+    const url = 'https://highlight.xyz/mint/ethereum:0x17747Ba2c75CF60d274BCD36210A5b4408A18A6E:0';
+    const resources = mintIngestorResources();
+    const template = await ingestor.createMintTemplateForUrl(resources, url);
+
+    const builder = new MintTemplateBuilder(template);
+    builder.validateMintTemplate();
+
+    expect(template.name).to.equal('Cosmic Communications');
+    expect(template.description).to.contain('Cosmic Communications continues with my Cosmic series');
+    const mintInstructions = template.mintInstructions as EVMMintInstructions;
+
+    expect(mintInstructions.chainId).to.equal(1);
+    expect(mintInstructions.contractAddress.toLowerCase()).to.equal('0x1bf979282181f2b7a640d17aB5D2e25125F2de5e'.toLowerCase());
+    expect(template.mintOutputContract?.address.toLowerCase()).to.equal('0x17747Ba2c75CF60d274BCD36210A5b4408A18A6E'.toLowerCase());
+    expect(mintInstructions.contractMethod).to.equal('vectorMint721');
+    expect(mintInstructions.contractParams).to.equal('[18, quantity, address]');
+    expect(mintInstructions.priceWei).to.equal('35800000000000000');
+
+    expect(template.featuredImageUrl).to.equal(
+      'https://highlight-creator-assets.highlight.xyz/main/image/8c8773ad-b501-4ca1-994b-72242308e767.jpeg',
+    );
+
+    if (template.creator) {
+      expect(template.creator.name).to.equal('markwebster');
+      expect(template.creator.walletAddress).to.equal('0x21ae441387c6bd5a4f9cb110684ba28761aa5a6d');
+      expect(template.creator.imageUrl).to.equal(
+        'https://highlight-creator-assets.highlight.xyz/main/image/9dfea465-d598-4ae8-a15a-9046c5f0a802.jpeg',
+      );
+    }
+
+    expect(template.marketingUrl).to.equal(url);
+    expect(template.availableForPurchaseStart?.getTime()).to.equal(+new Date('2023-09-26T16:00:00.000Z'));
     expect(template.availableForPurchaseEnd?.getTime()).to.equal(+new Date('2030-01-01T00:00:00.000Z'));
   });
 });


### PR DESCRIPTION
Fixes #62.\n\nThis updates the Highlight ingestor to use Highlight's current public GraphQL collection details API instead of the old marketplace/reservoir endpoints, and derives the mint vector id, creator metadata, price including mint fee, image, and sale timestamps from that API response.\n\nVerification:\n- FLOOR_PACKAGES_AUTH_TOKEN=dummy yarn build-types\n- FLOOR_PACKAGES_AUTH_TOKEN=dummy yarn lint\n- FLOOR_PACKAGES_AUTH_TOKEN=dummy ALCHEMY_API_KEY=dummy SIMULATE_DURING_TESTS=false NODE_OPTIONS="--loader ts-node/esm" ./node_modules/.bin/mocha --no-config --require ts-node/register --extension ts --timeout 20000 --exit test/ingestors/highlight.test.ts\n\nNote: the full repo test command currently exercises unrelated live-network ingestors and fails here without real Alchemy/Rarible credentials; the targeted Highlight suite passes 11/11.