### PR TITLE
Add Scatter Base mint ingestor

### DIFF
--- a/docs/scatter-base-eligibility.md
+++ b/docs/scatter-base-eligibility.md
@@ -1,0 +1,19 @@
+# Scatter Base Eligibility Evidence
+
+Captured from `https://api.scatter.art/v1/collection/{slug}` on 2026-05-12 09:50 UTC.
+
+The bounty requires the selected creator platform to have at least 10 prior Base mints with more than 100 unique collectors. Scatter exposes Base collection metadata where `chain_id` is the EVM chain id, `num_items` is the minted item count, and `num_owners` is the unique owner count.
+
+| Collection slug | Chain ID | Minted items | Unique owners | Contract |
+| --- | ---: | ---: | ---: | --- |
+| `base-mutant-ape-club` | 8453 | 13,596 | 2,298 | `0x9C5C875c6d0f73A7F939F487492d377ef70eD130` |
+| `kemonokaki` | 8453 | 10,000 | 3,585 | `0xEe7D1B184be8185Adc7052635329152a4d0cdEfA` |
+| `farcasterinterns` | 8453 | 10,000 | 5,574 | `0x4c8574512C09f0dCa20A37aB24447a2e1C10f223` |
+| `nounkes` | 8453 | 10,000 | 1,629 | `0x10aaeE376a1F7C5d70E72778FFF1b82C2E23ABe2` |
+| `world` | 8453 | 10,000 | 7,246 | `0x374dbb1d574FcC80938E1673e8aC18847F70fB3a` |
+| `toypunks` | 8453 | 10,000 | 823 | `0x971d200234B93f974482dd77e5C4AB722863Bf22` |
+| `base-gorilla-yacht-club` | 8453 | 10,000 | 421 | `0x20F353DBd0813E709C2259F1eb539870721087Bd` |
+| `nozukis` | 8453 | 10,000 | 1,095 | `0x9DEeC198516114e901928e5b6fBd1fB8864E5005` |
+| `art-penguins` | 8453 | 10,000 | 1,708 | `0x1f83fE35e75Ca3ff27c24f66CcfE6E9b365d6779` |
+| `based-3d-punks` | 8453 | 10,000 | 492 | `0x43b6a440B69C51E70FA10eB38dB9500ed37cDAd5` |
+

--- a/src/ingestors/index.ts
+++ b/src/ingestors/index.ts
@@ -8,6 +8,7 @@ import { FoundationIngestor } from './foundation';
 import { CoinbaseWalletIngestor } from './coinbase-wallet';
 import { ZoraInternalIngestor } from './zora-internal';
 import { RodeoIngestor } from './rodeo';
+import { ScatterIngestor } from './scatter';
 
 export type MintIngestionMap = {
   [key: string]: MintIngestor;
@@ -23,6 +24,7 @@ export const ALL_MINT_INGESTORS: MintIngestionMap = {
   highlight: new HighlightIngestor(),
   foundation: new FoundationIngestor(),
   'coinbase-wallet': new CoinbaseWalletIngestor(),
+  scatter: new ScatterIngestor(),
 };
 
 export * from './';

--- a/src/ingestors/scatter/abi.ts
+++ b/src/ingestors/scatter/abi.ts
@@ -1,0 +1,85 @@
+export const SCATTER_MINT_ABI = [
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'key',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'bytes32[]',
+            name: 'proof',
+            type: 'bytes32[]',
+          },
+        ],
+        internalType: 'struct Auth',
+        name: 'auth',
+        type: 'tuple',
+      },
+      {
+        internalType: 'uint256',
+        name: 'quantity',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: 'affiliate',
+        type: 'address',
+      },
+      {
+        internalType: 'bytes',
+        name: 'signature',
+        type: 'bytes',
+      },
+    ],
+    name: 'mint',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'key',
+        type: 'bytes32',
+      },
+    ],
+    name: 'listSupply',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'minter',
+        type: 'address',
+      },
+      {
+        internalType: 'bytes32',
+        name: 'key',
+        type: 'bytes32',
+      },
+    ],
+    name: 'minted',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];

--- a/src/ingestors/scatter/index.ts
+++ b/src/ingestors/scatter/index.ts
@@ -1,0 +1,141 @@
+import { MintContractOptions, MintIngestor, MintIngestorResources } from '../../lib/types/mint-ingestor';
+import { MintIngestionErrorName, MintIngestorError } from '../../lib/types/mint-ingestor-error';
+import { MintInstructionType, MintTemplate } from '../../lib/types/mint-template';
+import { MintTemplateBuilder } from '../../lib/builder/mint-template-builder';
+import {
+  findScatterMintOption,
+  getScatterCollectionBySlug,
+  resolveScatterCollectionForContract,
+  scatterSlugFromUrl,
+  scatterUrlForSlug,
+  SCATTER_ZERO_ADDRESS,
+} from './offchain-metadata';
+import { SCATTER_MINT_ABI } from './abi';
+import { ScatterCollection } from './types';
+
+export class ScatterIngestor implements MintIngestor {
+  configuration = {
+    supportsContractIsExpensive: true,
+  };
+
+  async supportsUrl(resources: MintIngestorResources, url: string): Promise<boolean> {
+    const slug = scatterSlugFromUrl(url);
+    if (!slug) {
+      return false;
+    }
+
+    const collection = await getScatterCollectionBySlug(resources, slug);
+    if (!collection || collection.chain_id !== 8453) {
+      return false;
+    }
+
+    return !!(await findScatterMintOption(resources, collection));
+  }
+
+  async supportsContract(resources: MintIngestorResources, contractOptions: MintContractOptions): Promise<boolean> {
+    const collection = await resolveScatterCollectionForContract(resources, contractOptions);
+    if (!collection) {
+      return false;
+    }
+
+    return !!(await findScatterMintOption(resources, collection));
+  }
+
+  async createMintTemplateForUrl(resources: MintIngestorResources, url: string): Promise<MintTemplate> {
+    const slug = scatterSlugFromUrl(url);
+    if (!slug) {
+      throw new MintIngestorError(MintIngestionErrorName.IncompatibleUrl, 'Incompatible URL');
+    }
+
+    const collection = await getScatterCollectionBySlug(resources, slug);
+    if (!collection || collection.chain_id !== 8453) {
+      throw new MintIngestorError(MintIngestionErrorName.IncompatibleUrl, 'Incompatible URL');
+    }
+
+    return this.createMintTemplate(resources, collection, url);
+  }
+
+  async createMintForContract(
+    resources: MintIngestorResources,
+    contractOptions: MintContractOptions,
+  ): Promise<MintTemplate> {
+    const collection = await resolveScatterCollectionForContract(resources, contractOptions);
+    if (!collection) {
+      throw new MintIngestorError(MintIngestionErrorName.CouldNotResolveMint, 'Collection not found');
+    }
+
+    return this.createMintTemplate(
+      resources,
+      collection,
+      contractOptions.url || scatterUrlForSlug(collection.slug || ''),
+    );
+  }
+
+  private async createMintTemplate(
+    resources: MintIngestorResources,
+    collection: ScatterCollection,
+    marketingUrl: string,
+  ): Promise<MintTemplate> {
+    const mintOption = await findScatterMintOption(resources, collection);
+    if (!mintOption) {
+      throw new MintIngestorError(MintIngestionErrorName.CouldNotResolveMint, 'Mint not available');
+    }
+
+    const { inviteList, mintResponse } = mintOption;
+    const image = collection.avatar_uri || collection.hero_uri || collection.banner_uri;
+    if (!image) {
+      throw new MintIngestorError(MintIngestionErrorName.MissingRequiredData, 'Image not available');
+    }
+
+    const startDate = inviteList.start_time ? new Date(inviteList.start_time) : new Date();
+    const endDate = inviteList.end_time ? new Date(inviteList.end_time) : new Date('2030-01-01T00:00:00Z');
+    const liveDate = new Date() > startDate ? new Date() : startDate;
+
+    const mintBuilder = new MintTemplateBuilder()
+      .setMintInstructionType(MintInstructionType.EVM_MINT)
+      .setPartnerName('Scatter')
+      .setMarketingUrl(marketingUrl)
+      .setName(collection.name)
+      .setDescription(collection.description || '')
+      .setFeaturedImageUrl(image)
+      .setMintOutputContract({ chainId: 8453, address: collection.address })
+      .setCreator({
+        name: collection.name,
+        walletAddress: collection.creator_address,
+        websiteUrl: collection.website || (collection.slug ? scatterUrlForSlug(collection.slug) : undefined),
+        twitterUsername: usernameFromXUrl(collection.twitter),
+      })
+      .setMintInstructions({
+        chainId: 8453,
+        contractAddress: collection.address,
+        contractMethod: 'mint',
+        contractParams: `[["${inviteList.root}", []], quantity, "${SCATTER_ZERO_ADDRESS}", "0x"]`,
+        abi: SCATTER_MINT_ABI,
+        priceWei: mintResponse.mintTransaction?.value || '0',
+        supportsQuantity: true,
+      })
+      .setAvailableForPurchaseStart(startDate)
+      .setAvailableForPurchaseEnd(endDate)
+      .setLiveDate(liveDate);
+
+    if (collection.hero_uri && collection.hero_uri !== image) {
+      mintBuilder.addImage(collection.hero_uri, 'hero');
+    }
+    if (collection.banner_uri && collection.banner_uri !== image) {
+      mintBuilder.addImage(collection.banner_uri, 'banner');
+    }
+
+    return mintBuilder.build();
+  }
+}
+
+const usernameFromXUrl = (url: string | null | undefined): string | undefined => {
+  if (!url) {
+    return;
+  }
+  try {
+    return new URL(url).pathname.split('/').filter(Boolean)[0];
+  } catch (error) {
+    return;
+  }
+};

--- a/src/ingestors/scatter/offchain-metadata.ts
+++ b/src/ingestors/scatter/offchain-metadata.ts
@@ -1,0 +1,289 @@
+import { MintContractOptions, MintIngestorResources } from '../../lib/types/mint-ingestor';
+import { ScatterCollection, ScatterInviteList, ScatterMintOption, ScatterMintResponse } from './types';
+
+const SCATTER_API_URL = 'https://api.scatter.art/v1';
+const SCATTER_TRPC_SEARCH_URL = 'https://www.scatter.art/api/trpc/search.searchCollections';
+const BASE_RPC_URL = 'https://mainnet.base.org';
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const TEST_MINTER_ADDRESS = '0x0000000000000000000000000000000000000001';
+const MAX_UINT32 = 4294967295;
+const MINT_SELECTOR = '0x4a21a2df';
+const NAME_SELECTOR = '0x06fdde03';
+const LIST_SUPPLY_SELECTOR = '0x9a7a973c';
+
+export const SCATTER_ZERO_ADDRESS = ZERO_ADDRESS;
+
+export const scatterUrlForSlug = (slug: string) => `https://www.scatter.art/collection/${slug}`;
+
+export const scatterSlugFromUrl = (url: string): string | undefined => {
+  const parsed = new URL(url);
+  if (parsed.hostname !== 'www.scatter.art' && parsed.hostname !== 'scatter.art') {
+    return;
+  }
+
+  const parts = parsed.pathname.split('/').filter(Boolean);
+  const collectionIndex = parts.indexOf('collection');
+  if (collectionIndex === -1) {
+    return;
+  }
+
+  return parts[collectionIndex + 1];
+};
+
+export const getScatterCollectionBySlug = async (
+  resources: MintIngestorResources,
+  slug: string,
+): Promise<ScatterCollection | undefined> => {
+  try {
+    const response = await resources.fetcher.get(`${SCATTER_API_URL}/collection/${slug}`);
+    return {
+      ...response.data,
+      slug,
+    };
+  } catch (error) {
+    return;
+  }
+};
+
+export const getScatterInviteLists = async (
+  resources: MintIngestorResources,
+  slug: string,
+): Promise<ScatterInviteList[]> => {
+  try {
+    const response = await resources.fetcher.get(`${SCATTER_API_URL}/collection/${slug}/eligible-invite-lists`);
+    return response.data || [];
+  } catch (error) {
+    return [];
+  }
+};
+
+export const getScatterMintResponse = async (
+  resources: MintIngestorResources,
+  collection: ScatterCollection,
+  inviteList: ScatterInviteList,
+): Promise<ScatterMintResponse | undefined> => {
+  try {
+    const response = await resources.fetcher.post(
+      `${SCATTER_API_URL}/mint`,
+      {
+        collectionAddress: collection.address,
+        chainId: collection.chain_id,
+        minterAddress: TEST_MINTER_ADDRESS,
+        lists: [{ id: inviteList.id, quantity: 1 }],
+      },
+      {
+        headers: {
+          'content-type': 'application/json',
+        },
+      },
+    );
+    return response.data;
+  } catch (error) {
+    return;
+  }
+};
+
+export const findScatterMintOption = async (
+  resources: MintIngestorResources,
+  collection: ScatterCollection,
+): Promise<ScatterMintOption | undefined> => {
+  if (!collection.slug) {
+    return;
+  }
+  if (collection.max_items && collection.num_items && collection.num_items >= collection.max_items) {
+    return;
+  }
+
+  const inviteLists = await getScatterInviteLists(resources, collection.slug);
+  for (const inviteList of inviteLists) {
+    if (!isNativePublicInviteList(inviteList) || !isInviteListActive(inviteList)) {
+      continue;
+    }
+
+    const listSupply = await getListSupply(resources, collection.address, inviteList.root);
+    if (listSupply !== undefined && inviteList.list_limit && inviteList.list_limit !== MAX_UINT32) {
+      if (listSupply >= BigInt(inviteList.list_limit)) {
+        continue;
+      }
+    }
+
+    const mintResponse = await getScatterMintResponse(resources, collection, inviteList);
+    if (!mintResponse || !isUsableMintResponse(collection, mintResponse)) {
+      continue;
+    }
+
+    return {
+      inviteList,
+      mintResponse,
+    };
+  }
+
+  return;
+};
+
+export const resolveScatterCollectionForContract = async (
+  resources: MintIngestorResources,
+  contractOptions: MintContractOptions,
+): Promise<ScatterCollection | undefined> => {
+  if (contractOptions.chainId !== 8453) {
+    return;
+  }
+
+  if (contractOptions.url) {
+    const slug = scatterSlugFromUrl(contractOptions.url);
+    if (slug) {
+      const collection = await getScatterCollectionBySlug(resources, slug);
+      if (
+        collection &&
+        collection.chain_id === contractOptions.chainId &&
+        sameAddress(collection.address, contractOptions.contractAddress)
+      ) {
+        return collection;
+      }
+    }
+  }
+
+  const contractName = await readBaseContractName(resources, contractOptions.contractAddress);
+  if (!contractName) {
+    return;
+  }
+
+  const searchResults = await searchScatterCollections(resources, contractName, contractOptions.chainId);
+  const matchingCollection = searchResults.find((collection) =>
+    sameAddress(collection.address, contractOptions.contractAddress),
+  );
+  if (!matchingCollection?.slug) {
+    return;
+  }
+
+  return getScatterCollectionBySlug(resources, matchingCollection.slug);
+};
+
+const searchScatterCollections = async (
+  resources: MintIngestorResources,
+  query: string,
+  chainId: number,
+): Promise<ScatterCollection[]> => {
+  try {
+    const input = {
+      0: {
+        json: {
+          sortCategory: 'mints',
+          sortTimeFrame: 'all',
+          sortDirection: 'desc',
+          queryStr: query,
+          chainsFilter: [chainId],
+          limit: 24,
+        },
+      },
+    };
+    const response = await resources.fetcher.get(SCATTER_TRPC_SEARCH_URL, {
+      params: {
+        batch: '1',
+        input: JSON.stringify(input),
+      },
+    });
+    return response.data?.[0]?.result?.data?.json?.collections || [];
+  } catch (error) {
+    return [];
+  }
+};
+
+const isNativePublicInviteList = (inviteList: ScatterInviteList) => {
+  return (
+    inviteList.currency_address.toLowerCase() === ZERO_ADDRESS &&
+    inviteList.decimals === 18 &&
+    (inviteList.unit_size ?? 1) === 1
+  );
+};
+
+const isInviteListActive = (inviteList: ScatterInviteList) => {
+  const now = new Date();
+  if (inviteList.start_time && new Date(inviteList.start_time) > now) {
+    return false;
+  }
+  if (inviteList.end_time && new Date(inviteList.end_time) <= now) {
+    return false;
+  }
+  return true;
+};
+
+const isUsableMintResponse = (collection: ScatterCollection, response: ScatterMintResponse | undefined) => {
+  if (!response?.mintTransaction) {
+    return false;
+  }
+  if (!sameAddress(response.mintTransaction.to, collection.address)) {
+    return false;
+  }
+  if (!response.mintTransaction.data.startsWith(MINT_SELECTOR)) {
+    return false;
+  }
+  return !response.erc20s?.length;
+};
+
+const readBaseContractName = async (
+  resources: MintIngestorResources,
+  contractAddress: string,
+): Promise<string | undefined> => {
+  try {
+    const response = await resources.fetcher.post(BASE_RPC_URL, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_call',
+      params: [
+        {
+          to: contractAddress,
+          data: NAME_SELECTOR,
+        },
+        'latest',
+      ],
+    });
+    return decodeAbiString(response.data?.result);
+  } catch (error) {
+    return;
+  }
+};
+
+const getListSupply = async (
+  resources: MintIngestorResources,
+  contractAddress: string,
+  root: string,
+): Promise<bigint | undefined> => {
+  try {
+    const response = await resources.fetcher.post(BASE_RPC_URL, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_call',
+      params: [
+        {
+          to: contractAddress,
+          data: `${LIST_SUPPLY_SELECTOR}${root.replace(/^0x/, '')}`,
+        },
+        'latest',
+      ],
+    });
+    if (!response.data?.result) {
+      return;
+    }
+    return BigInt(response.data.result);
+  } catch (error) {
+    return;
+  }
+};
+
+const decodeAbiString = (hexValue: string | undefined): string | undefined => {
+  if (!hexValue?.startsWith('0x')) {
+    return;
+  }
+
+  const data = Buffer.from(hexValue.slice(2), 'hex');
+  if (data.length < 64) {
+    return;
+  }
+
+  const offset = Number(BigInt(`0x${data.subarray(0, 32).toString('hex')}`));
+  const length = Number(BigInt(`0x${data.subarray(offset, offset + 32).toString('hex')}`));
+  return data.subarray(offset + 32, offset + 32 + length).toString('utf8');
+};
+
+const sameAddress = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();

--- a/src/ingestors/scatter/offchain-metadata.ts
+++ b/src/ingestors/scatter/offchain-metadata.ts
@@ -188,10 +188,24 @@ const searchScatterCollections = async (
         input: JSON.stringify(input),
       },
     });
-    return response.data?.[0]?.result?.data?.json?.collections || [];
+    const collections = response.data?.[0]?.result?.data?.json?.collections;
+    if (!Array.isArray(collections)) {
+      return [];
+    }
+
+    return collections.filter(isScatterSearchCollection);
   } catch (error) {
     return [];
   }
+};
+
+const isScatterSearchCollection = (collection: unknown): collection is ScatterCollection => {
+  if (!collection || typeof collection !== 'object') {
+    return false;
+  }
+
+  const value = collection as Partial<Record<keyof ScatterCollection, unknown>>;
+  return typeof value.slug === 'string' && typeof value.address === 'string';
 };
 
 const isNativePublicInviteList = (inviteList: ScatterInviteList) => {

--- a/src/ingestors/scatter/offchain-metadata.ts
+++ b/src/ingestors/scatter/offchain-metadata.ts
@@ -100,9 +100,14 @@ export const findScatterMintOption = async (
       continue;
     }
 
-    const listSupply = await getListSupply(resources, collection.address, inviteList.root);
-    if (listSupply !== undefined && inviteList.list_limit && inviteList.list_limit !== MAX_UINT32) {
-      if (listSupply >= BigInt(inviteList.list_limit)) {
+    const listLimit = inviteList.list_limit;
+    if (listLimit !== null && listLimit !== undefined && listLimit !== MAX_UINT32) {
+      if (listLimit <= 0) {
+        continue;
+      }
+
+      const listSupply = await getListSupply(resources, collection.address, inviteList.root);
+      if (listSupply !== undefined && listSupply >= BigInt(listLimit)) {
         continue;
       }
     }
@@ -286,4 +291,6 @@ const decodeAbiString = (hexValue: string | undefined): string | undefined => {
   return data.subarray(offset + 32, offset + 32 + length).toString('utf8');
 };
 
-const sameAddress = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();
+const sameAddress = (a: unknown, b: unknown) => {
+  return typeof a === 'string' && typeof b === 'string' && a.toLowerCase() === b.toLowerCase();
+};

--- a/src/ingestors/scatter/types.ts
+++ b/src/ingestors/scatter/types.ts
@@ -1,0 +1,52 @@
+export type ScatterCollection = {
+  id?: string;
+  slug?: string;
+  name: string;
+  description?: string | null;
+  address: string;
+  chain_id: number;
+  max_items?: number | null;
+  num_items?: number | null;
+  num_owners?: number | null;
+  avatar_uri?: string | null;
+  banner_uri?: string | null;
+  hero_uri?: string | null;
+  creator_address?: string | null;
+  twitter?: string | null;
+  discord?: string | null;
+  website?: string | null;
+  abi?: string;
+};
+
+export type ScatterInviteList = {
+  id: string;
+  name: string;
+  root: string;
+  address: string;
+  currency_address: string;
+  currency_symbol: string;
+  token_price: string;
+  decimals: number;
+  start_time?: string | null;
+  end_time?: string | null;
+  wallet_limit?: number | null;
+  list_limit?: number | null;
+  unit_size?: number | null;
+};
+
+export type ScatterMintResponse = {
+  mintTransaction?: {
+    to: string;
+    value: string;
+    data: string;
+  };
+  erc20s?: {
+    address: string;
+    amount: string;
+  }[];
+};
+
+export type ScatterMintOption = {
+  inviteList: ScatterInviteList;
+  mintResponse: ScatterMintResponse;
+};

--- a/test/ingestors/scatter.test.ts
+++ b/test/ingestors/scatter.test.ts
@@ -1,0 +1,64 @@
+import { EVMMintInstructions } from '../../src/lib/types/mint-template';
+import { MintTemplateBuilder } from '../../src/lib/builder/mint-template-builder';
+import { ScatterIngestor } from '../../src/ingestors/scatter';
+import { basicIngestorTests } from '../shared/basic-ingestor-tests';
+import { expect } from 'chai';
+import { mintIngestorResources } from '../../src/lib/resources';
+
+const resources = mintIngestorResources();
+
+describe('Scatter', function () {
+  this.timeout(60000);
+
+  basicIngestorTests(
+    new ScatterIngestor(),
+    resources,
+    {
+      successUrls: ['https://www.scatter.art/collection/tribe-of-girl'],
+      failureUrls: [
+        'https://www.scatter.art/search',
+        'https://example.com/collection/g-punks',
+        'https://www.scatter.art/collection/g-punks',
+      ],
+      successContracts: [
+        {
+          chainId: 8453,
+          contractAddress: '0xf1A741Af9FaB327aF4A858F735129Ac89055ECBE',
+          url: 'https://www.scatter.art/collection/tribe-of-girl',
+        },
+      ],
+      failureContracts: [
+        { chainId: 1, contractAddress: '0xa648572b95bf1d260Daa472839D2e34005139bc8' },
+        { chainId: 8453, contractAddress: '0x965ef172b303b0bcdc38669df1de3c26bad2db8a' },
+      ],
+    },
+    {
+      8453: '0x1c1c6c0',
+    },
+  );
+
+  it('createMintTemplateForUrl: returns Scatter mint instructions for a Base collection', async function () {
+    const ingestor = new ScatterIngestor();
+    const template = await ingestor.createMintTemplateForUrl(resources, 'https://www.scatter.art/collection/tribe-of-girl');
+    const builder = new MintTemplateBuilder(template);
+    builder.validateMintTemplate();
+
+    expect(template.name).to.equal('Tribes of Anime Girl');
+    expect(template.description).to.equal('This is Tribes of Anime Girl.. anime');
+    expect(template.featuredImageUrl).to.equal('https://ucarecdn.com/733dcb7e-ab04-4a95-8bc8-ec8c9948f4f9/');
+    expect(template.marketingUrl).to.equal('https://www.scatter.art/collection/tribe-of-girl');
+    expect(template.creator?.walletAddress).to.equal('0xDd9226160aE11c33CaDFA78A9dB017164bf3772F');
+    expect(template.creator?.twitterUsername).to.equal('sssbbbbbbuuu');
+    expect(template.mintOutputContract?.address).to.equal('0xf1A741Af9FaB327aF4A858F735129Ac89055ECBE');
+
+    const mintInstructions = template.mintInstructions as EVMMintInstructions;
+    expect(mintInstructions.chainId).to.equal(8453);
+    expect(mintInstructions.contractAddress).to.equal('0xf1A741Af9FaB327aF4A858F735129Ac89055ECBE');
+    expect(mintInstructions.contractMethod).to.equal('mint');
+    expect(mintInstructions.contractParams).to.equal(
+      '[["0x0000000000000000000000000000000000000000000000000000000000000005", []], quantity, "0x0000000000000000000000000000000000000000", "0x"]',
+    );
+    expect(mintInstructions.priceWei).to.equal('0');
+    expect(mintInstructions.supportsQuantity).to.be.true;
+  });
+});

--- a/test/ingestors/scatter.test.ts
+++ b/test/ingestors/scatter.test.ts
@@ -3,9 +3,22 @@ import { MintTemplateBuilder } from '../../src/lib/builder/mint-template-builder
 import { ScatterIngestor } from '../../src/ingestors/scatter';
 import { basicIngestorTests } from '../shared/basic-ingestor-tests';
 import { expect } from 'chai';
+import { getScatterCollectionBySlug } from '../../src/ingestors/scatter/offchain-metadata';
 import { mintIngestorResources } from '../../src/lib/resources';
 
 const resources = mintIngestorResources();
+const eligibleBaseCollectionSlugs = [
+  'base-mutant-ape-club',
+  'kemonokaki',
+  'farcasterinterns',
+  'nounkes',
+  'world',
+  'toypunks',
+  'base-gorilla-yacht-club',
+  'nozukis',
+  'art-penguins',
+  'based-3d-punks',
+];
 
 describe('Scatter', function () {
   this.timeout(60000);
@@ -36,6 +49,27 @@ describe('Scatter', function () {
       8453: '0x1c1c6c0',
     },
   );
+
+  it('documents Scatter eligibility with 10 prior Base collections over 100 collectors', async function () {
+    const evidence = await Promise.all(
+      eligibleBaseCollectionSlugs.map(async (slug) => {
+        const collection = await getScatterCollectionBySlug(resources, slug);
+        return {
+          slug,
+          chainId: collection?.chain_id,
+          mints: collection?.num_items || 0,
+          owners: collection?.num_owners || 0,
+        };
+      }),
+    );
+
+    const failures = evidence.filter((collection) => {
+      return collection.chainId !== 8453 || collection.mints < 10 || collection.owners <= 100;
+    });
+
+    expect(evidence.length).to.equal(10);
+    expect(failures).to.deep.equal([]);
+  });
 
   it('createMintTemplateForUrl: returns Scatter mint instructions for a Base collection', async function () {
     const ingestor = new ScatterIngestor();


### PR DESCRIPTION
## Summary
- add a Scatter ingestor for Base collection mint URLs and contracts
- resolve Scatter collection data, active native invite lists, and validated mint transaction pricing from Scatter public APIs
- skip sold-out invite lists using Base `listSupply` reads before building a mint template
- wire Scatter into `ALL_MINT_INGESTORS`
- address review feedback for list-limit handling and defensive Scatter search-result validation

## Bounty
For #11. Scatter supports Base mints; the included fixture collection `tribe-of-girl` has 1,668 minted items and 680 owners on Base, and exposes an active public native mint list.

The test suite now includes live eligibility evidence for 10 Scatter Base collections that each exceed the bounty thresholds of 10 prior Base mints and 100 unique collectors:

| Collection | Chain | Mints | Owners |
| --- | ---: | ---: | ---: |
| base-mutant-ape-club | 8453 | 13,596 | 2,298 |
| kemonokaki | 8453 | 10,000 | 3,585 |
| farcasterinterns | 8453 | 10,000 | 5,574 |
| nounkes | 8453 | 10,000 | 1,629 |
| world | 8453 | 10,000 | 7,246 |
| toypunks | 8453 | 10,000 | 823 |
| base-gorilla-yacht-club | 8453 | 10,000 | 421 |
| nozukis | 8453 | 10,000 | 1,095 |
| art-penguins | 8453 | 10,000 | 1,708 |
| based-3d-punks | 8453 | 10,000 | 492 |

## Verification
- `FLOOR_PACKAGES_AUTH_TOKEN=dummy yarn build-types`
- `FLOOR_PACKAGES_AUTH_TOKEN=dummy yarn lint`
- `FLOOR_PACKAGES_AUTH_TOKEN=dummy ALCHEMY_API_KEY=dummy SIMULATE_DURING_TESTS=false NODE_OPTIONS="--loader ts-node/esm" ./node_modules/.bin/mocha --no-config --require ts-node/register --extension ts --timeout 60000 --exit test/ingestors/scatter.test.ts` - 10 passing
