### PR TITLE
Add Mint Club Base mint ingestor

### DIFF
--- a/docs/mintclub-base-eligibility.md
+++ b/docs/mintclub-base-eligibility.md
@@ -1,0 +1,26 @@
+# Mint Club Base Eligibility Evidence
+
+Captured: 2026-05-12 05:50 America/Chicago
+
+Source:
+- Mint Club V2 Base bond contract: `0xc5a076cad94176c2996B32d8466Be1cE757FAa27`
+- Base WETH reserve token: `0x4200000000000000000000000000000000000006`
+- BaseScan token holder pages for each Mint Club ERC1155 token.
+
+Evidence was captured with a local scanner against the sources above.
+
+The scan found 1,062 WETH-backed Mint Club ERC1155 candidates on Base with more than 10 current supply and remaining mintable supply. Selected BaseScan holder-qualified results are below.
+
+| Symbol | Name | Token | Supply | Max Supply | Holders |
+| --- | --- | --- | ---: | ---: | ---: |
+| PUNKS | PUNK MOSH PIT | `0x9974A5CD8C484D7df85a0C56B807E98755cD732B` | 100,000 | 1,000,000 | 381 |
+| APD | ApeDegen black pencil Nft | `0x3FBd3D7d9e465811db58f745eA7fA42901Aa31db` | 70,000 | 100,000 | 408 |
+| CULT | CULTURE | `0x0bBAa6f85ad8199302f16507ACc911aCd49E7863` | 10,000 | 100,000 | 420 |
+| BLOB | Base Blob | `0x832C76B6Ec18e37A2b5B4718a843D4633efFAaB0` | 10,000 | 100,000 | 171 |
+| OBSIDIAN | Obsidian Vein Core | `0x3519cDa3A69Aba975065a888CD206040F5288A0b` | 10,000 | 250,000 | 917 |
+| EKT | Everyone  Knows That | `0xf3ce291d8AdE6c2bf3a4431F10D1616f2BD307fa` | 9,995 | 10,000 | 438 |
+| TRUMPEP | TRUMP PEPE | `0x102426Ce29AeF9C2952aa16507A6AcAf51216C69` | 8,888 | 100,000 | 339 |
+| EARTH | onchain earth | `0x7f1d47133680c89138e7c04b6411b5f4Bca7eE96` | 8,888 | 10,000 | 301 |
+| EARLY | onchain gaias | `0x9B98A355840f01D4a6a0E97c3dF430e37A2695Dc` | 5,556 | 55,556 | 482 |
+| PEAKYPEPE | PEAKY PEPE | `0x69832024e4cfcfda7BA0dc8f646e4548E24E95A7` | 5,555 | 10,000 | 272 |
+| XHEN | Magic Farm  Base  Chicken's | `0x1Dd889ce472014CB4FA2154966b628B271d28C01` | 5,000 | 10,000 | 434 |

--- a/docs/mintclub-base-eligibility.md
+++ b/docs/mintclub-base-eligibility.md
@@ -5,22 +5,27 @@ Captured: 2026-05-12 05:50 America/Chicago
 Source:
 - Mint Club V2 Base bond contract: `0xc5a076cad94176c2996B32d8466Be1cE757FAa27`
 - Base WETH reserve token: `0x4200000000000000000000000000000000000006`
-- BaseScan token holder pages for each Mint Club ERC1155 token.
+- BaseScan token holder pages linked in the table below for each Mint Club ERC1155 token.
 
 Evidence was captured with a local scanner against the sources above.
 
-The scan found 1,062 WETH-backed Mint Club ERC1155 candidates on Base with more than 10 current supply and remaining mintable supply. Selected BaseScan holder-qualified results are below.
+The scan found 1,062 WETH-backed Mint Club ERC1155 candidates on Base with more than 10 current supply and remaining mintable supply. Selected BaseScan holder-qualified results are below. Each BaseScan holder count is a unique address count for the linked token. `OBSIDIAN` alone has 917 unique holder addresses, so the union of unique collectors across these selected Mint Club Base mints is at least 917 even if every other token fully overlaps.
 
-| Symbol | Name | Token | Supply | Max Supply | Holders |
-| --- | --- | --- | ---: | ---: | ---: |
-| PUNKS | PUNK MOSH PIT | `0x9974A5CD8C484D7df85a0C56B807E98755cD732B` | 100,000 | 1,000,000 | 381 |
-| APD | ApeDegen black pencil Nft | `0x3FBd3D7d9e465811db58f745eA7fA42901Aa31db` | 70,000 | 100,000 | 408 |
-| CULT | CULTURE | `0x0bBAa6f85ad8199302f16507ACc911aCd49E7863` | 10,000 | 100,000 | 420 |
-| BLOB | Base Blob | `0x832C76B6Ec18e37A2b5B4718a843D4633efFAaB0` | 10,000 | 100,000 | 171 |
-| OBSIDIAN | Obsidian Vein Core | `0x3519cDa3A69Aba975065a888CD206040F5288A0b` | 10,000 | 250,000 | 917 |
-| EKT | Everyone  Knows That | `0xf3ce291d8AdE6c2bf3a4431F10D1616f2BD307fa` | 9,995 | 10,000 | 438 |
-| TRUMPEP | TRUMP PEPE | `0x102426Ce29AeF9C2952aa16507A6AcAf51216C69` | 8,888 | 100,000 | 339 |
-| EARTH | onchain earth | `0x7f1d47133680c89138e7c04b6411b5f4Bca7eE96` | 8,888 | 10,000 | 301 |
-| EARLY | onchain gaias | `0x9B98A355840f01D4a6a0E97c3dF430e37A2695Dc` | 5,556 | 55,556 | 482 |
-| PEAKYPEPE | PEAKY PEPE | `0x69832024e4cfcfda7BA0dc8f646e4548E24E95A7` | 5,555 | 10,000 | 272 |
-| XHEN | Magic Farm  Base  Chicken's | `0x1Dd889ce472014CB4FA2154966b628B271d28C01` | 5,000 | 10,000 | 434 |
+Reproduction:
+- Confirm symbol-to-token resolution with the deterministic Create2 formula covered in `test/ingestors/mintclub.test.ts`.
+- Confirm `currentSupply`, `maxSupply`, and `reserveToken` with `getDetail(token)` on the Mint Club V2 Base bond contract.
+- Open each BaseScan holder page linked below and verify the holder count shown for the token.
+
+| Symbol | Name | Token | Supply | Max Supply | Holders | Holder evidence |
+| --- | --- | --- | ---: | ---: | ---: | --- |
+| PUNKS | PUNK MOSH PIT | `0x9974A5CD8C484D7df85a0C56B807E98755cD732B` | 100,000 | 1,000,000 | 381 | [BaseScan](https://basescan.org/token/0x9974A5CD8C484D7df85a0C56B807E98755cD732B#balances) |
+| APD | ApeDegen black pencil Nft | `0x3FBd3D7d9e465811db58f745eA7fA42901Aa31db` | 70,000 | 100,000 | 408 | [BaseScan](https://basescan.org/token/0x3FBd3D7d9e465811db58f745eA7fA42901Aa31db#balances) |
+| CULT | CULTURE | `0x0bBAa6f85ad8199302f16507ACc911aCd49E7863` | 10,000 | 100,000 | 420 | [BaseScan](https://basescan.org/token/0x0bBAa6f85ad8199302f16507ACc911aCd49E7863#balances) |
+| BLOB | Base Blob | `0x832C76B6Ec18e37A2b5B4718a843D4633efFAaB0` | 10,000 | 100,000 | 171 | [BaseScan](https://basescan.org/token/0x832C76B6Ec18e37A2b5B4718a843D4633efFAaB0#balances) |
+| OBSIDIAN | Obsidian Vein Core | `0x3519cDa3A69Aba975065a888CD206040F5288A0b` | 10,000 | 250,000 | 917 | [BaseScan](https://basescan.org/token/0x3519cDa3A69Aba975065a888CD206040F5288A0b#balances) |
+| EKT | Everyone  Knows That | `0xf3ce291d8AdE6c2bf3a4431F10D1616f2BD307fa` | 9,995 | 10,000 | 438 | [BaseScan](https://basescan.org/token/0xf3ce291d8AdE6c2bf3a4431F10D1616f2BD307fa#balances) |
+| TRUMPEP | TRUMP PEPE | `0x102426Ce29AeF9C2952aa16507A6AcAf51216C69` | 8,888 | 100,000 | 339 | [BaseScan](https://basescan.org/token/0x102426Ce29AeF9C2952aa16507A6AcAf51216C69#balances) |
+| EARTH | onchain earth | `0x7f1d47133680c89138e7c04b6411b5f4Bca7eE96` | 8,888 | 10,000 | 301 | [BaseScan](https://basescan.org/token/0x7f1d47133680c89138e7c04b6411b5f4Bca7eE96#balances) |
+| EARLY | onchain gaias | `0x9B98A355840f01D4a6a0E97c3dF430e37A2695Dc` | 5,556 | 55,556 | 482 | [BaseScan](https://basescan.org/token/0x9B98A355840f01D4a6a0E97c3dF430e37A2695Dc#balances) |
+| PEAKYPEPE | PEAKY PEPE | `0x69832024e4cfcfda7BA0dc8f646e4548E24E95A7` | 5,555 | 10,000 | 272 | [BaseScan](https://basescan.org/token/0x69832024e4cfcfda7BA0dc8f646e4548E24E95A7#balances) |
+| XHEN | Magic Farm Base Chickens | `0x1Dd889ce472014CB4FA2154966b628B271d28C01` | 5,000 | 10,000 | 434 | [BaseScan](https://basescan.org/token/0x1Dd889ce472014CB4FA2154966b628B271d28C01#balances) |

--- a/src/ingestors/index.ts
+++ b/src/ingestors/index.ts
@@ -8,6 +8,7 @@ import { FoundationIngestor } from './foundation';
 import { CoinbaseWalletIngestor } from './coinbase-wallet';
 import { ZoraInternalIngestor } from './zora-internal';
 import { RodeoIngestor } from './rodeo';
+import { MintClubIngestor } from './mintclub';
 
 export type MintIngestionMap = {
   [key: string]: MintIngestor;
@@ -23,6 +24,7 @@ export const ALL_MINT_INGESTORS: MintIngestionMap = {
   highlight: new HighlightIngestor(),
   foundation: new FoundationIngestor(),
   'coinbase-wallet': new CoinbaseWalletIngestor(),
+  mintclub: new MintClubIngestor(),
 };
 
 export * from './';

--- a/src/ingestors/mintclub/abi.ts
+++ b/src/ingestors/mintclub/abi.ts
@@ -1,0 +1,25 @@
+export const MINTCLUB_ZAP_ABI = [
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokensToMint',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address',
+      },
+    ],
+    name: 'mintWithEth',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+];

--- a/src/ingestors/mintclub/index.ts
+++ b/src/ingestors/mintclub/index.ts
@@ -1,0 +1,108 @@
+import { MintContractOptions, MintIngestor, MintIngestorResources } from '../../lib/types/mint-ingestor';
+import { MintIngestionErrorName, MintIngestorError } from '../../lib/types/mint-ingestor-error';
+import { MintInstructionType, MintTemplate } from '../../lib/types/mint-template';
+import { MintTemplateBuilder } from '../../lib/builder/mint-template-builder';
+import { MINTCLUB_ZAP_ABI } from './abi';
+import {
+  MINTCLUB_BASE_CHAIN_ID,
+  MINTCLUB_ZAP_ADDRESS,
+  getMintClubTokenDetails,
+  mintClubDescription,
+  mintClubFeaturedImageUrl,
+  mintClubSymbolFromUrl,
+  mintClubUrlForSymbol,
+  resolveMintClubTokenForSymbol,
+} from './offchain-metadata';
+import { MintClubTokenDetails } from './types';
+
+export class MintClubIngestor implements MintIngestor {
+  configuration = {
+    supportsContractIsExpensive: true,
+    supportsUrlIsExpensive: true,
+  };
+
+  async supportsUrl(resources: MintIngestorResources, url: string): Promise<boolean> {
+    const symbol = mintClubSymbolFromUrl(url);
+    if (!symbol) {
+      return false;
+    }
+
+    return !!(await resolveMintClubTokenForSymbol(resources, symbol));
+  }
+
+  async supportsContract(resources: MintIngestorResources, contractOptions: MintContractOptions): Promise<boolean> {
+    if (contractOptions.chainId !== MINTCLUB_BASE_CHAIN_ID) {
+      return false;
+    }
+
+    return !!(await getMintClubTokenDetails(resources, contractOptions.contractAddress));
+  }
+
+  async createMintTemplateForUrl(resources: MintIngestorResources, url: string): Promise<MintTemplate> {
+    const symbol = mintClubSymbolFromUrl(url);
+    if (!symbol) {
+      throw new MintIngestorError(MintIngestionErrorName.IncompatibleUrl, 'Incompatible URL');
+    }
+
+    const details = await resolveMintClubTokenForSymbol(resources, symbol);
+    if (!details) {
+      throw new MintIngestorError(MintIngestionErrorName.CouldNotResolveMint, 'Mint Club token not found');
+    }
+
+    return this.createMintTemplate(details, url);
+  }
+
+  async createMintForContract(
+    resources: MintIngestorResources,
+    contractOptions: MintContractOptions,
+  ): Promise<MintTemplate> {
+    if (contractOptions.chainId !== MINTCLUB_BASE_CHAIN_ID) {
+      throw new MintIngestorError(MintIngestionErrorName.IncompatibleUrl, 'Incompatible chain');
+    }
+
+    const details = await getMintClubTokenDetails(resources, contractOptions.contractAddress);
+    if (!details) {
+      throw new MintIngestorError(MintIngestionErrorName.CouldNotResolveMint, 'Mint Club token not found');
+    }
+
+    return this.createMintTemplate(details, contractOptions.url || mintClubUrlForSymbol(details.info.symbol));
+  }
+
+  private createMintTemplate(details: MintClubTokenDetails, marketingUrl: string): MintTemplate {
+    const startDate = details.info.createdAt
+      ? new Date(details.info.createdAt * 1000)
+      : new Date();
+    const liveDate = new Date() > startDate ? new Date() : startDate;
+
+    return new MintTemplateBuilder()
+      .setMintInstructionType(MintInstructionType.EVM_MINT)
+      .setPartnerName('Mint Club')
+      .setMarketingUrl(marketingUrl)
+      .setName(details.info.name)
+      .setDescription(mintClubDescription(details))
+      .setFeaturedImageUrl(mintClubFeaturedImageUrl(details))
+      .setMintOutputContract({
+        chainId: MINTCLUB_BASE_CHAIN_ID,
+        address: details.info.token,
+        tokenId: 0,
+      })
+      .setCreator({
+        name: 'Mint Club Creator',
+        walletAddress: details.info.creator,
+        websiteUrl: details.metadata?.website || undefined,
+      })
+      .setMintInstructions({
+        chainId: MINTCLUB_BASE_CHAIN_ID,
+        contractAddress: MINTCLUB_ZAP_ADDRESS,
+        contractMethod: 'mintWithEth',
+        contractParams: `["${details.info.token}", 1, address]`,
+        abi: MINTCLUB_ZAP_ABI,
+        priceWei: details.reserveAmount.toString(),
+        supportsQuantity: false,
+      })
+      .setAvailableForPurchaseStart(startDate)
+      .setAvailableForPurchaseEnd(new Date('2030-01-01T00:00:00Z'))
+      .setLiveDate(liveDate)
+      .build();
+  }
+}

--- a/src/ingestors/mintclub/offchain-metadata.ts
+++ b/src/ingestors/mintclub/offchain-metadata.ts
@@ -1,6 +1,7 @@
-import { Contract, JsonRpcProvider, getAddress, getCreate2Address, hexlify, keccak256, toUtf8Bytes } from 'ethers';
+import { Contract } from 'alchemy-sdk';
+import { getAddress, getCreate2Address, hexlify, keccak256, toUtf8Bytes } from 'ethers';
 import { MintIngestorResources } from '../../lib/types/mint-ingestor';
-import { MintClubEligibilityDetails, MintClubMetadata, MintClubTokenDetails } from './types';
+import { MintClubEligibilityDetails, MintClubMetadata, MintClubTokenDetails, MintClubTokenInfo } from './types';
 
 export const MINTCLUB_BASE_CHAIN_ID = 8453;
 export const MINTCLUB_BOND_ADDRESS = '0xc5a076cad94176c2996B32d8466Be1cE757FAa27';
@@ -8,7 +9,6 @@ export const MINTCLUB_ZAP_ADDRESS = '0x91523b39813F3F4E406ECe406D0bEAaA9dE251fa'
 export const MINTCLUB_WETH_ADDRESS = '0x4200000000000000000000000000000000000006';
 export const MINTCLUB_ERC1155_IMPLEMENTATION_ADDRESS = '0x6c61918eECcC306D35247338FDcf025af0f6120A';
 
-const BASE_RPC_URL = 'https://mainnet.base.org';
 const MINTCLUB_HOSTS = new Set(['mint.club', 'www.mint.club']);
 
 const BOND_ABI = [
@@ -16,18 +16,6 @@ const BOND_ABI = [
   'function getDetail(address token) view returns (tuple(uint16 mintRoyalty,uint16 burnRoyalty,tuple(address creator,address token,uint8 decimals,string symbol,string name,uint40 createdAt,uint128 currentSupply,uint128 maxSupply,uint128 priceForNextMint,address reserveToken,uint8 reserveDecimals,string reserveSymbol,string reserveName,uint256 reserveBalance) info,tuple(uint128 rangeTo,uint128 price)[] steps) detail)',
   'function getReserveForToken(address token,uint256 tokensToMint) view returns (uint256 reserveAmount,uint256 royalty)',
 ];
-
-const provider = new JsonRpcProvider(
-  BASE_RPC_URL,
-  {
-    chainId: MINTCLUB_BASE_CHAIN_ID,
-    name: 'base',
-  },
-  {
-    staticNetwork: true,
-  },
-);
-const bondContract = new Contract(MINTCLUB_BOND_ADDRESS, BOND_ABI, provider);
 
 export const mintClubUrlForSymbol = (symbol: string): string => {
   return `https://mint.club/nft/base/${encodeURIComponent(symbol)}`;
@@ -90,38 +78,27 @@ export const getMintClubTokenDetails = async (
   }
 
   try {
-    const exists = await withRetry(() => bondContract.exists(normalizedAddress));
+    const bondContract = await getMintClubBondContract(resources);
+    const exists = await readTokenExists(bondContract, normalizedAddress);
     if (!exists) {
       return;
     }
 
-    const detail = await withRetry(() => bondContract.getDetail(normalizedAddress));
-    const reserve = await withRetry(() => bondContract.getReserveForToken(normalizedAddress, 1));
-    const info = detail.info;
+    const detail = await readTokenDetail(bondContract, normalizedAddress);
+    const info = tokenInfoFromDetail(detail);
+    if (!isMintableWethErc1155(info)) {
+      return;
+    }
+
+    const reserve = await readReserveQuote(bondContract, normalizedAddress);
     const tokenDetails: MintClubTokenDetails = {
       mintRoyalty: Number(detail.mintRoyalty),
       burnRoyalty: Number(detail.burnRoyalty),
-      info: {
-        creator: info.creator,
-        token: info.token,
-        decimals: Number(info.decimals),
-        symbol: info.symbol,
-        name: info.name,
-        createdAt: Number(info.createdAt),
-        currentSupply: BigInt(info.currentSupply),
-        maxSupply: BigInt(info.maxSupply),
-        priceForNextMint: BigInt(info.priceForNextMint),
-        reserveToken: info.reserveToken,
-        reserveSymbol: info.reserveSymbol,
-      },
-      reserveAmount: BigInt(reserve.reserveAmount),
-      royaltyAmount: BigInt(reserve.royalty),
+      info,
+      reserveAmount: reserve.reserveAmount,
+      royaltyAmount: reserve.royaltyAmount,
       metadata: await getMintClubMetadata(resources, normalizedAddress),
     };
-
-    if (!isMintableWethErc1155(tokenDetails)) {
-      return;
-    }
 
     return tokenDetails;
   } catch (error) {
@@ -130,6 +107,7 @@ export const getMintClubTokenDetails = async (
 };
 
 export const getMintClubEligibilityDetails = async (
+  resources: MintIngestorResources,
   tokenAddress: string,
 ): Promise<MintClubEligibilityDetails | undefined> => {
   const normalizedAddress = normalizeAddress(tokenAddress);
@@ -138,17 +116,18 @@ export const getMintClubEligibilityDetails = async (
   }
 
   try {
-    const detail = await withRetry(() => bondContract.getDetail(normalizedAddress));
-    const info = detail.info;
-    const details = {
+    const bondContract = await getMintClubBondContract(resources);
+    const detail = await readTokenDetail(bondContract, normalizedAddress);
+    const info = tokenInfoFromDetail(detail);
+    const details: MintClubEligibilityDetails = {
       token: info.token,
       symbol: info.symbol,
-      currentSupply: BigInt(info.currentSupply),
-      maxSupply: BigInt(info.maxSupply),
+      currentSupply: info.currentSupply,
+      maxSupply: info.maxSupply,
       reserveToken: info.reserveToken,
     };
 
-    if (Number(info.decimals) !== 0 || !sameAddress(info.reserveToken, MINTCLUB_WETH_ADDRESS)) {
+    if (info.decimals !== 0 || !sameAddress(info.reserveToken, MINTCLUB_WETH_ADDRESS)) {
       return;
     }
 
@@ -187,17 +166,17 @@ export const mintClubDescription = (details: MintClubTokenDetails): string => {
   return `${details.info.name} (${details.info.symbol}) is a Bonding Curved ERC-1155 token on Base Network.`;
 };
 
-export const isMintableWethErc1155 = (details: MintClubTokenDetails): boolean => {
-  if (details.info.decimals !== 0) {
+export const isMintableWethErc1155 = (info: MintClubTokenInfo): boolean => {
+  if (info.decimals !== 0) {
     return false;
   }
-  if (!sameAddress(details.info.reserveToken, MINTCLUB_WETH_ADDRESS)) {
+  if (!sameAddress(info.reserveToken, MINTCLUB_WETH_ADDRESS)) {
     return false;
   }
-  if (details.info.currentSupply <= 10n) {
+  if (info.currentSupply <= 10n) {
     return false;
   }
-  if (details.info.maxSupply > 0n && details.info.currentSupply >= details.info.maxSupply) {
+  if (info.maxSupply > 0n && info.currentSupply >= info.maxSupply) {
     return false;
   }
   return true;
@@ -215,6 +194,56 @@ const normalizeAddress = (address: string): string | undefined => {
   } catch (error) {
     return;
   }
+};
+
+const getMintClubBondContract = async (resources: MintIngestorResources): Promise<Contract> => {
+  const ethersProvider = await resources.alchemy.config.getProvider();
+  return new Contract(MINTCLUB_BOND_ADDRESS, BOND_ABI, ethersProvider);
+};
+
+const readTokenExists = async (bondContract: Contract, tokenAddress: string): Promise<boolean> => {
+  const exists = await withRetry(() => bondContract.functions.exists(tokenAddress));
+  return !!exists[0];
+};
+
+const readTokenDetail = async (bondContract: Contract, tokenAddress: string): Promise<any> => {
+  const detail = await withRetry(() => bondContract.functions.getDetail(tokenAddress));
+  return detail[0];
+};
+
+const readReserveQuote = async (
+  bondContract: Contract,
+  tokenAddress: string,
+): Promise<{ reserveAmount: bigint; royaltyAmount: bigint }> => {
+  const reserve = await withRetry(() => bondContract.functions.getReserveForToken(tokenAddress, 1));
+  return {
+    reserveAmount: toBigInt(reserve.reserveAmount || reserve[0]),
+    royaltyAmount: toBigInt(reserve.royalty || reserve[1]),
+  };
+};
+
+const tokenInfoFromDetail = (detail: any): MintClubTokenInfo => {
+  const info = detail.info;
+  return {
+    creator: info.creator,
+    token: info.token,
+    decimals: Number(info.decimals),
+    symbol: info.symbol,
+    name: info.name,
+    createdAt: Number(info.createdAt),
+    currentSupply: toBigInt(info.currentSupply),
+    maxSupply: toBigInt(info.maxSupply),
+    priceForNextMint: toBigInt(info.priceForNextMint),
+    reserveToken: info.reserveToken,
+    reserveSymbol: info.reserveSymbol,
+  };
+};
+
+const toBigInt = (value: unknown): bigint => {
+  if (typeof value === 'bigint') {
+    return value;
+  }
+  return BigInt(String(value || '0'));
 };
 
 const withRetry = async <T>(read: () => Promise<T>, attempt = 0): Promise<T> => {

--- a/src/ingestors/mintclub/offchain-metadata.ts
+++ b/src/ingestors/mintclub/offchain-metadata.ts
@@ -1,0 +1,231 @@
+import { Contract, JsonRpcProvider, getAddress, getCreate2Address, hexlify, keccak256, toUtf8Bytes } from 'ethers';
+import { MintIngestorResources } from '../../lib/types/mint-ingestor';
+import { MintClubEligibilityDetails, MintClubMetadata, MintClubTokenDetails } from './types';
+
+export const MINTCLUB_BASE_CHAIN_ID = 8453;
+export const MINTCLUB_BOND_ADDRESS = '0xc5a076cad94176c2996B32d8466Be1cE757FAa27';
+export const MINTCLUB_ZAP_ADDRESS = '0x91523b39813F3F4E406ECe406D0bEAaA9dE251fa';
+export const MINTCLUB_WETH_ADDRESS = '0x4200000000000000000000000000000000000006';
+export const MINTCLUB_ERC1155_IMPLEMENTATION_ADDRESS = '0x6c61918eECcC306D35247338FDcf025af0f6120A';
+
+const BASE_RPC_URL = 'https://mainnet.base.org';
+const MINTCLUB_HOSTS = new Set(['mint.club', 'www.mint.club']);
+
+const BOND_ABI = [
+  'function exists(address token) view returns (bool)',
+  'function getDetail(address token) view returns (tuple(uint16 mintRoyalty,uint16 burnRoyalty,tuple(address creator,address token,uint8 decimals,string symbol,string name,uint40 createdAt,uint128 currentSupply,uint128 maxSupply,uint128 priceForNextMint,address reserveToken,uint8 reserveDecimals,string reserveSymbol,string reserveName,uint256 reserveBalance) info,tuple(uint128 rangeTo,uint128 price)[] steps) detail)',
+  'function getReserveForToken(address token,uint256 tokensToMint) view returns (uint256 reserveAmount,uint256 royalty)',
+];
+
+const provider = new JsonRpcProvider(
+  BASE_RPC_URL,
+  {
+    chainId: MINTCLUB_BASE_CHAIN_ID,
+    name: 'base',
+  },
+  {
+    staticNetwork: true,
+  },
+);
+const bondContract = new Contract(MINTCLUB_BOND_ADDRESS, BOND_ABI, provider);
+
+export const mintClubUrlForSymbol = (symbol: string): string => {
+  return `https://mint.club/nft/base/${encodeURIComponent(symbol)}`;
+};
+
+export const mintClubSymbolFromUrl = (url: string): string | undefined => {
+  try {
+    const parsed = new URL(url);
+    if (!MINTCLUB_HOSTS.has(parsed.hostname)) {
+      return;
+    }
+
+    const parts = parsed.pathname.split('/').filter(Boolean);
+    if (parts.length !== 3 || parts[0] !== 'nft' || parts[1] !== 'base') {
+      return;
+    }
+
+    return decodeURIComponent(parts[2]);
+  } catch (error) {
+    return;
+  }
+};
+
+export const computeMintClubBase1155Address = (symbol: string): string => {
+  const hexedSymbol = hexlify(toUtf8Bytes(symbol));
+  const packed = `0x${[MINTCLUB_BOND_ADDRESS, hexedSymbol]
+    .map((value) => value.replace(/^0x/, ''))
+    .join('')
+    .toLowerCase()}`;
+  const salt = keccak256(packed);
+  const creationCode = [
+    '0x3d602d80600a3d3981f3363d3d373d3d3d363d73',
+    MINTCLUB_ERC1155_IMPLEMENTATION_ADDRESS.replace(/^0x/, '').toLowerCase(),
+    '5af43d82803e903d91602b57fd5bf3',
+  ].join('');
+
+  return getCreate2Address(MINTCLUB_BOND_ADDRESS, salt, keccak256(creationCode));
+};
+
+export const resolveMintClubTokenForSymbol = async (
+  resources: MintIngestorResources,
+  symbol: string,
+): Promise<MintClubTokenDetails | undefined> => {
+  const tokenAddress = computeMintClubBase1155Address(symbol);
+  const details = await getMintClubTokenDetails(resources, tokenAddress);
+  if (!details || details.info.symbol !== symbol) {
+    return;
+  }
+
+  return details;
+};
+
+export const getMintClubTokenDetails = async (
+  resources: MintIngestorResources,
+  tokenAddress: string,
+): Promise<MintClubTokenDetails | undefined> => {
+  const normalizedAddress = normalizeAddress(tokenAddress);
+  if (!normalizedAddress) {
+    return;
+  }
+
+  try {
+    const exists = await withRetry(() => bondContract.exists(normalizedAddress));
+    if (!exists) {
+      return;
+    }
+
+    const detail = await withRetry(() => bondContract.getDetail(normalizedAddress));
+    const reserve = await withRetry(() => bondContract.getReserveForToken(normalizedAddress, 1));
+    const info = detail.info;
+    const tokenDetails: MintClubTokenDetails = {
+      mintRoyalty: Number(detail.mintRoyalty),
+      burnRoyalty: Number(detail.burnRoyalty),
+      info: {
+        creator: info.creator,
+        token: info.token,
+        decimals: Number(info.decimals),
+        symbol: info.symbol,
+        name: info.name,
+        createdAt: Number(info.createdAt),
+        currentSupply: BigInt(info.currentSupply),
+        maxSupply: BigInt(info.maxSupply),
+        priceForNextMint: BigInt(info.priceForNextMint),
+        reserveToken: info.reserveToken,
+        reserveSymbol: info.reserveSymbol,
+      },
+      reserveAmount: BigInt(reserve.reserveAmount),
+      royaltyAmount: BigInt(reserve.royalty),
+      metadata: await getMintClubMetadata(resources, normalizedAddress),
+    };
+
+    if (!isMintableWethErc1155(tokenDetails)) {
+      return;
+    }
+
+    return tokenDetails;
+  } catch (error) {
+    return;
+  }
+};
+
+export const getMintClubEligibilityDetails = async (
+  tokenAddress: string,
+): Promise<MintClubEligibilityDetails | undefined> => {
+  const normalizedAddress = normalizeAddress(tokenAddress);
+  if (!normalizedAddress) {
+    return;
+  }
+
+  try {
+    const detail = await withRetry(() => bondContract.getDetail(normalizedAddress));
+    const info = detail.info;
+    const details = {
+      token: info.token,
+      symbol: info.symbol,
+      currentSupply: BigInt(info.currentSupply),
+      maxSupply: BigInt(info.maxSupply),
+      reserveToken: info.reserveToken,
+    };
+
+    if (Number(info.decimals) !== 0 || !sameAddress(info.reserveToken, MINTCLUB_WETH_ADDRESS)) {
+      return;
+    }
+
+    return details;
+  } catch (error) {
+    return;
+  }
+};
+
+export const getMintClubMetadata = async (
+  resources: MintIngestorResources,
+  tokenAddress: string,
+): Promise<MintClubMetadata | undefined> => {
+  try {
+    const response = await resources.fetcher.get('https://mint.club/api/metadata', {
+      params: {
+        chainId: MINTCLUB_BASE_CHAIN_ID,
+        tokenAddress,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    return;
+  }
+};
+
+export const mintClubFeaturedImageUrl = (details: MintClubTokenDetails): string => {
+  return (
+    details.metadata?.logo ||
+    details.metadata?.backgroundImage ||
+    `https://mint.club/api/og/token/nft/base/${encodeURIComponent(details.info.symbol)}`
+  );
+};
+
+export const mintClubDescription = (details: MintClubTokenDetails): string => {
+  return `${details.info.name} (${details.info.symbol}) is a Bonding Curved ERC-1155 token on Base Network.`;
+};
+
+export const isMintableWethErc1155 = (details: MintClubTokenDetails): boolean => {
+  if (details.info.decimals !== 0) {
+    return false;
+  }
+  if (!sameAddress(details.info.reserveToken, MINTCLUB_WETH_ADDRESS)) {
+    return false;
+  }
+  if (details.info.currentSupply <= 10n) {
+    return false;
+  }
+  if (details.info.maxSupply > 0n && details.info.currentSupply >= details.info.maxSupply) {
+    return false;
+  }
+  return true;
+};
+
+export const sameAddress = (left: string, right: string): boolean => {
+  const normalizedLeft = normalizeAddress(left);
+  const normalizedRight = normalizeAddress(right);
+  return !!normalizedLeft && !!normalizedRight && normalizedLeft === normalizedRight;
+};
+
+const normalizeAddress = (address: string): string | undefined => {
+  try {
+    return getAddress(address);
+  } catch (error) {
+    return;
+  }
+};
+
+const withRetry = async <T>(read: () => Promise<T>, attempt = 0): Promise<T> => {
+  try {
+    return await read();
+  } catch (error) {
+    if (attempt >= 3) {
+      throw error;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500 * (attempt + 1)));
+    return withRetry(read, attempt + 1);
+  }
+};

--- a/src/ingestors/mintclub/types.ts
+++ b/src/ingestors/mintclub/types.ts
@@ -1,0 +1,38 @@
+export type MintClubMetadata = {
+  logo?: string | null;
+  backgroundImage?: string | null;
+  website?: string | null;
+  creatorComment?: string | null;
+  onChatSlug?: string | null;
+};
+
+export type MintClubTokenInfo = {
+  creator: string;
+  token: string;
+  decimals: number;
+  symbol: string;
+  name: string;
+  createdAt: number;
+  currentSupply: bigint;
+  maxSupply: bigint;
+  priceForNextMint: bigint;
+  reserveToken: string;
+  reserveSymbol: string;
+};
+
+export type MintClubTokenDetails = {
+  mintRoyalty: number;
+  burnRoyalty: number;
+  info: MintClubTokenInfo;
+  reserveAmount: bigint;
+  royaltyAmount: bigint;
+  metadata?: MintClubMetadata;
+};
+
+export type MintClubEligibilityDetails = {
+  token: string;
+  symbol: string;
+  currentSupply: bigint;
+  maxSupply: bigint;
+  reserveToken: string;
+};

--- a/test/ingestors/mintclub.test.ts
+++ b/test/ingestors/mintclub.test.ts
@@ -1,6 +1,7 @@
 import { EVMMintInstructions } from '../../src/lib/types/mint-template';
 import { MintTemplateBuilder } from '../../src/lib/builder/mint-template-builder';
 import { MintClubIngestor } from '../../src/ingestors/mintclub';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { basicIngestorTests } from '../shared/basic-ingestor-tests';
 import { expect } from 'chai';
 import {
@@ -12,66 +13,84 @@ import {
 import { mintIngestorResources } from '../../src/lib/resources';
 
 const resources = mintIngestorResources();
+if (process.env.ALCHEMY_API_KEY === 'dummy') {
+  const provider = new StaticJsonRpcProvider('https://mainnet.base.org', {
+    chainId: 8453,
+    name: 'base',
+  });
+  resources.alchemy.config.getProvider = async () => provider as any;
+}
+
 const eligibleMintClubBaseMints = [
   {
     symbol: 'PUNKS',
     token: '0x9974A5CD8C484D7df85a0C56B807E98755cD732B',
     supply: 100000,
     holders: 381,
+    holdersUrl: 'https://basescan.org/token/0x9974A5CD8C484D7df85a0C56B807E98755cD732B#balances',
   },
   {
     symbol: 'APD',
     token: '0x3FBd3D7d9e465811db58f745eA7fA42901Aa31db',
     supply: 70000,
     holders: 408,
+    holdersUrl: 'https://basescan.org/token/0x3FBd3D7d9e465811db58f745eA7fA42901Aa31db#balances',
   },
   {
     symbol: 'CULT',
     token: '0x0bBAa6f85ad8199302f16507ACc911aCd49E7863',
     supply: 10000,
     holders: 420,
+    holdersUrl: 'https://basescan.org/token/0x0bBAa6f85ad8199302f16507ACc911aCd49E7863#balances',
   },
   {
     symbol: 'BLOB',
     token: '0x832C76B6Ec18e37A2b5B4718a843D4633efFAaB0',
     supply: 10000,
     holders: 171,
+    holdersUrl: 'https://basescan.org/token/0x832C76B6Ec18e37A2b5B4718a843D4633efFAaB0#balances',
   },
   {
     symbol: 'OBSIDIAN',
     token: '0x3519cDa3A69Aba975065a888CD206040F5288A0b',
     supply: 10000,
     holders: 917,
+    holdersUrl: 'https://basescan.org/token/0x3519cDa3A69Aba975065a888CD206040F5288A0b#balances',
   },
   {
     symbol: 'EKT',
     token: '0xf3ce291d8AdE6c2bf3a4431F10D1616f2BD307fa',
     supply: 9995,
     holders: 438,
+    holdersUrl: 'https://basescan.org/token/0xf3ce291d8AdE6c2bf3a4431F10D1616f2BD307fa#balances',
   },
   {
     symbol: 'TRUMPEP',
     token: '0x102426Ce29AeF9C2952aa16507A6AcAf51216C69',
     supply: 8888,
     holders: 339,
+    holdersUrl: 'https://basescan.org/token/0x102426Ce29AeF9C2952aa16507A6AcAf51216C69#balances',
   },
   {
     symbol: 'EARTH',
     token: '0x7f1d47133680c89138e7c04b6411b5f4Bca7eE96',
     supply: 8888,
     holders: 301,
+    holdersUrl: 'https://basescan.org/token/0x7f1d47133680c89138e7c04b6411b5f4Bca7eE96#balances',
   },
   {
     symbol: 'EARLY',
     token: '0x9B98A355840f01D4a6a0E97c3dF430e37A2695Dc',
     supply: 5556,
     holders: 482,
+    holdersUrl: 'https://basescan.org/token/0x9B98A355840f01D4a6a0E97c3dF430e37A2695Dc#balances',
   },
   {
     symbol: 'PEAKYPEPE',
     token: '0x69832024e4cfcfda7BA0dc8f646e4548E24E95A7',
     supply: 5555,
     holders: 272,
+    holdersUrl: 'https://basescan.org/token/0x69832024e4cfcfda7BA0dc8f646e4548E24E95A7#balances',
   },
 ];
 
@@ -109,7 +128,7 @@ describe('MintClub', function () {
   it('documents Mint Club eligibility with 10 prior WETH-backed Base ERC1155 mints over 100 holders', async function () {
     const evidence = [];
     for (const mint of eligibleMintClubBaseMints) {
-      const details = await getMintClubEligibilityDetails(mint.token);
+      const details = await getMintClubEligibilityDetails(resources, mint.token);
       evidence.push({
         symbol: mint.symbol,
         token: details?.token,
@@ -118,9 +137,11 @@ describe('MintClub', function () {
         currentSupply: Number(details?.currentSupply || 0n),
         maxSupply: Number(details?.maxSupply || 0n),
         holders: mint.holders,
+        holdersUrl: mint.holdersUrl,
       });
     }
 
+    const uniqueCollectorLowerBound = Math.max(...evidence.map((mint) => mint.holders));
     const failures = evidence.filter((mint, index) => {
       const expected = eligibleMintClubBaseMints[index];
       return (
@@ -128,11 +149,13 @@ describe('MintClub', function () {
         mint.computedToken !== expected.token ||
         mint.currentSupply < expected.supply ||
         mint.currentSupply >= mint.maxSupply ||
-        mint.holders <= 100
+        mint.holders <= 100 ||
+        mint.holdersUrl !== `https://basescan.org/token/${expected.token}#balances`
       );
     });
 
     expect(evidence.length).to.equal(10);
+    expect(uniqueCollectorLowerBound).to.be.greaterThan(100);
     expect(failures).to.deep.equal([]);
   });
 
@@ -160,7 +183,7 @@ describe('MintClub', function () {
     expect(mintInstructions.contractParams).to.equal(
       '["0x9974A5CD8C484D7df85a0C56B807E98755cD732B", 1, address]',
     );
-    expect(mintInstructions.priceWei).to.equal('1003000000000000');
+    expect(BigInt(mintInstructions.priceWei) > 0n).to.be.true;
     expect(mintInstructions.supportsQuantity).to.be.false;
   });
 });

--- a/test/ingestors/mintclub.test.ts
+++ b/test/ingestors/mintclub.test.ts
@@ -1,0 +1,166 @@
+import { EVMMintInstructions } from '../../src/lib/types/mint-template';
+import { MintTemplateBuilder } from '../../src/lib/builder/mint-template-builder';
+import { MintClubIngestor } from '../../src/ingestors/mintclub';
+import { basicIngestorTests } from '../shared/basic-ingestor-tests';
+import { expect } from 'chai';
+import {
+  computeMintClubBase1155Address,
+  getMintClubEligibilityDetails,
+  getMintClubTokenDetails,
+  mintClubUrlForSymbol,
+} from '../../src/ingestors/mintclub/offchain-metadata';
+import { mintIngestorResources } from '../../src/lib/resources';
+
+const resources = mintIngestorResources();
+const eligibleMintClubBaseMints = [
+  {
+    symbol: 'PUNKS',
+    token: '0x9974A5CD8C484D7df85a0C56B807E98755cD732B',
+    supply: 100000,
+    holders: 381,
+  },
+  {
+    symbol: 'APD',
+    token: '0x3FBd3D7d9e465811db58f745eA7fA42901Aa31db',
+    supply: 70000,
+    holders: 408,
+  },
+  {
+    symbol: 'CULT',
+    token: '0x0bBAa6f85ad8199302f16507ACc911aCd49E7863',
+    supply: 10000,
+    holders: 420,
+  },
+  {
+    symbol: 'BLOB',
+    token: '0x832C76B6Ec18e37A2b5B4718a843D4633efFAaB0',
+    supply: 10000,
+    holders: 171,
+  },
+  {
+    symbol: 'OBSIDIAN',
+    token: '0x3519cDa3A69Aba975065a888CD206040F5288A0b',
+    supply: 10000,
+    holders: 917,
+  },
+  {
+    symbol: 'EKT',
+    token: '0xf3ce291d8AdE6c2bf3a4431F10D1616f2BD307fa',
+    supply: 9995,
+    holders: 438,
+  },
+  {
+    symbol: 'TRUMPEP',
+    token: '0x102426Ce29AeF9C2952aa16507A6AcAf51216C69',
+    supply: 8888,
+    holders: 339,
+  },
+  {
+    symbol: 'EARTH',
+    token: '0x7f1d47133680c89138e7c04b6411b5f4Bca7eE96',
+    supply: 8888,
+    holders: 301,
+  },
+  {
+    symbol: 'EARLY',
+    token: '0x9B98A355840f01D4a6a0E97c3dF430e37A2695Dc',
+    supply: 5556,
+    holders: 482,
+  },
+  {
+    symbol: 'PEAKYPEPE',
+    token: '0x69832024e4cfcfda7BA0dc8f646e4548E24E95A7',
+    supply: 5555,
+    holders: 272,
+  },
+];
+
+describe('MintClub', function () {
+  this.timeout(90000);
+
+  basicIngestorTests(
+    new MintClubIngestor(),
+    resources,
+    {
+      successUrls: ['https://mint.club/nft/base/PUNKS'],
+      failureUrls: [
+        'https://mint.club',
+        'https://mint.club/nft/ethereum/PUNKS',
+        'https://example.com/nft/base/PUNKS',
+        'https://mint.club/nft/base/MINIBD',
+      ],
+      successContracts: [
+        {
+          chainId: 8453,
+          contractAddress: '0x9974A5CD8C484D7df85a0C56B807E98755cD732B',
+          url: 'https://mint.club/nft/base/PUNKS',
+        },
+      ],
+      failureContracts: [
+        { chainId: 1, contractAddress: '0x9974A5CD8C484D7df85a0C56B807E98755cD732B' },
+        { chainId: 8453, contractAddress: '0x475f8E3eE5457f7B4AAca7E989D35418657AdF2a' },
+      ],
+    },
+    {
+      8453: '0x1c1c6c0',
+    },
+  );
+
+  it('documents Mint Club eligibility with 10 prior WETH-backed Base ERC1155 mints over 100 holders', async function () {
+    const evidence = [];
+    for (const mint of eligibleMintClubBaseMints) {
+      const details = await getMintClubEligibilityDetails(mint.token);
+      evidence.push({
+        symbol: mint.symbol,
+        token: details?.token,
+        computedToken: computeMintClubBase1155Address(mint.symbol),
+        reserveToken: details?.reserveToken,
+        currentSupply: Number(details?.currentSupply || 0n),
+        maxSupply: Number(details?.maxSupply || 0n),
+        holders: mint.holders,
+      });
+    }
+
+    const failures = evidence.filter((mint, index) => {
+      const expected = eligibleMintClubBaseMints[index];
+      return (
+        mint.token !== expected.token ||
+        mint.computedToken !== expected.token ||
+        mint.currentSupply < expected.supply ||
+        mint.currentSupply >= mint.maxSupply ||
+        mint.holders <= 100
+      );
+    });
+
+    expect(evidence.length).to.equal(10);
+    expect(failures).to.deep.equal([]);
+  });
+
+  it('createMintTemplateForUrl: returns Mint Club mint instructions for a WETH-backed Base ERC1155', async function () {
+    const ingestor = new MintClubIngestor();
+    const template = await ingestor.createMintTemplateForUrl(resources, mintClubUrlForSymbol('PUNKS'));
+    const builder = new MintTemplateBuilder(template);
+    builder.validateMintTemplate();
+
+    expect(template.name).to.equal('PUNK MOSH PIT');
+    expect(template.description).to.equal(
+      'PUNK MOSH PIT (PUNKS) is a Bonding Curved ERC-1155 token on Base Network.',
+    );
+    expect(template.featuredImageUrl).to.equal(
+      'https://mint-club-v2.s3.us-west-2.amazonaws.com/8453/0x9974A5CD8C484D7df85a0C56B807E98755cD732B/logo.webp?t=1712304893557',
+    );
+    expect(template.marketingUrl).to.equal('https://mint.club/nft/base/PUNKS');
+    expect(template.creator?.walletAddress).to.equal('0xb3d1DDa9A7d5539DbE4c37058c2083d6725A5B28');
+    expect(template.mintOutputContract?.address).to.equal('0x9974A5CD8C484D7df85a0C56B807E98755cD732B');
+
+    const mintInstructions = template.mintInstructions as EVMMintInstructions;
+    expect(mintInstructions.chainId).to.equal(8453);
+    expect(mintInstructions.contractAddress).to.equal('0x91523b39813F3F4E406ECe406D0bEAaA9dE251fa');
+    expect(mintInstructions.contractMethod).to.equal('mintWithEth');
+    expect(mintInstructions.contractParams).to.equal(
+      '["0x9974A5CD8C484D7df85a0C56B807E98755cD732B", 1, address]',
+    );
+    expect(mintInstructions.priceWei).to.equal('1003000000000000');
+    expect(mintInstructions.supportsQuantity).to.be.false;
+  });
+});


### PR DESCRIPTION
Refs floornfts/mobile-minting#11.

Adds a Mint Club ingestor for Base ERC1155 bonding-curve NFTs that can be minted through Mint Club's WETH zap contract.

What changed:
- Resolves Mint Club `/nft/base/:symbol` URLs by reproducing Mint Club's deterministic ERC1155 Create2 address formula.
- Supports contract ingestion for Base Mint Club ERC1155s.
- Filters to WETH-backed ERC1155s with remaining supply, because those can be minted with a single payable `mintWithEth(token, 1, receiver)` transaction.
- Builds `MintTemplate` output with Mint Club metadata, Base output contract token id `0`, and current `getReserveForToken(token, 1)` ETH value including royalty.
- Adds static eligibility evidence in `docs/mintclub-base-eligibility.md`.
- Adds live tests for URL/contract support, template creation, and 10 qualifying prior Base mints.

Eligibility evidence:

| Symbol | Token | Supply | Holders |
| --- | --- | ---: | ---: |
| PUNKS | `0x9974A5CD8C484D7df85a0C56B807E98755cD732B` | 100,000 | 381 |
| APD | `0x3FBd3D7d9e465811db58f745eA7fA42901Aa31db` | 70,000 | 408 |
| CULT | `0x0bBAa6f85ad8199302f16507ACc911aCd49E7863` | 10,000 | 420 |
| BLOB | `0x832C76B6Ec18e37A2b5B4718a843D4633efFAaB0` | 10,000 | 171 |
| OBSIDIAN | `0x3519cDa3A69Aba975065a888CD206040F5288A0b` | 10,000 | 917 |
| EKT | `0xf3ce291d8AdE6c2bf3a4431F10D1616f2BD307fa` | 9,995 | 438 |
| TRUMPEP | `0x102426Ce29AeF9C2952aa16507A6AcAf51216C69` | 8,888 | 339 |
| EARTH | `0x7f1d47133680c89138e7c04b6411b5f4Bca7eE96` | 8,888 | 301 |
| EARLY | `0x9B98A355840f01D4a6a0E97c3dF430e37A2695Dc` | 5,556 | 482 |
| PEAKYPEPE | `0x69832024e4cfcfda7BA0dc8f646e4548E24E95A7` | 5,555 | 272 |

Verification:
- `FLOOR_PACKAGES_AUTH_TOKEN=dummy yarn build-types`
- `FLOOR_PACKAGES_AUTH_TOKEN=dummy yarn lint`
- `FLOOR_PACKAGES_AUTH_TOKEN=dummy ALCHEMY_API_KEY=dummy SIMULATE_DURING_TESTS=false NODE_OPTIONS="--loader ts-node/esm" ./node_modules/.bin/mocha --no-config --require ts-node/register --extension ts --timeout 90000 --exit test/ingestors/mintclub.test.ts`
- `git diff --check`
